### PR TITLE
feat:[#6] 동행 게시글 및 댓글 Entity 정의 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/example/gabojago_server/GabojagoServerApplication.java
+++ b/src/main/java/com/example/gabojago_server/GabojagoServerApplication.java
@@ -2,14 +2,12 @@ package com.example.gabojago_server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class GabojagoServerApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(GabojagoServerApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(GabojagoServerApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/example/gabojago_server/config/JpaConfig.java
+++ b/src/main/java/com/example/gabojago_server/config/JpaConfig.java
@@ -1,7 +1,9 @@
 package com.example.gabojago_server.config;
 
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
+@Configuration
 public class JpaConfig {
 }

--- a/src/main/java/com/example/gabojago_server/model/article/AccompanyArticle.java
+++ b/src/main/java/com/example/gabojago_server/model/article/AccompanyArticle.java
@@ -1,0 +1,42 @@
+package com.example.gabojago_server.model.article;
+
+import com.example.gabojago_server.model.member.Member;
+import lombok.*;
+
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import java.time.LocalDate;
+
+
+@Entity
+@Getter
+@DiscriminatorValue("AccompanyArticle")
+@ToString(callSuper = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AccompanyArticle extends Article {
+
+    private String region; // 지역
+
+    @Column(name = "start_date")
+    private LocalDate startDate; // 동행 시작 날짜
+
+    @Column(name = "end_date")
+    private LocalDate endDate; // 동행 마지막 날짜
+
+    private int recruitNumber; // 모집인원
+
+    @Builder
+    public AccompanyArticle(Member writer, String title,
+                            String content, String region,
+                            LocalDate startDate, LocalDate endDate,
+                            int recruitNumber) {
+        this.writer = writer;
+        this.title = title;
+        this.content = content;
+        this.region = region;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.recruitNumber = recruitNumber;
+    }
+}

--- a/src/main/java/com/example/gabojago_server/model/article/Article.java
+++ b/src/main/java/com/example/gabojago_server/model/article/Article.java
@@ -1,0 +1,44 @@
+package com.example.gabojago_server.model.article;
+
+import com.example.gabojago_server.model.common.BaseTimeEntity;
+import com.example.gabojago_server.model.member.Member;
+import lombok.Getter;
+import lombok.ToString;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+@Entity
+@Getter
+@Inheritance(strategy = InheritanceType.JOINED)
+@ToString(exclude = "writer")
+public abstract class Article extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    protected Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    protected Member writer;
+
+    @Column(nullable = false)
+    protected String title; //제목
+
+    @Column(nullable = false, length = 2000)
+    protected String content; // 내용
+
+    protected int review; //조회수
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Article)) return false;
+        Article article = (Article) o;
+        return this.getId() != null && Objects.equals(id, article.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/example/gabojago_server/model/articlecomment/ArticleComment.java
+++ b/src/main/java/com/example/gabojago_server/model/articlecomment/ArticleComment.java
@@ -1,0 +1,49 @@
+package com.example.gabojago_server.model.articlecomment;
+
+import com.example.gabojago_server.model.article.Article;
+import com.example.gabojago_server.model.common.BaseTimeEntity;
+import com.example.gabojago_server.model.member.Member;
+import lombok.*;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(exclude = {"writer", "article"})
+public class ArticleComment extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "article_comment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private Article article;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private Member writer;
+
+    @Column(nullable = false, length = 500)
+    private String content; // 댓글 내용
+
+    @Builder
+    public ArticleComment(Article article, Member writer, String content) {
+        this.article = article;
+        this.writer = writer;
+        this.content = content;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ArticleComment)) return false;
+        ArticleComment that = (ArticleComment) o;
+        return this.getId() != null && Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/example/gabojago_server/repository/article/AccompanyRepository.java
+++ b/src/main/java/com/example/gabojago_server/repository/article/AccompanyRepository.java
@@ -1,0 +1,7 @@
+package com.example.gabojago_server.repository.article;
+
+import com.example.gabojago_server.model.article.AccompanyArticle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccompanyRepository extends JpaRepository<AccompanyArticle, Long> {
+}

--- a/src/main/java/com/example/gabojago_server/repository/articlecomment/ArticleCommentRepository.java
+++ b/src/main/java/com/example/gabojago_server/repository/articlecomment/ArticleCommentRepository.java
@@ -1,0 +1,7 @@
+package com.example.gabojago_server.repository.articlecomment;
+
+import com.example.gabojago_server.model.articlecomment.ArticleComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
+}

--- a/src/test/java/com/example/gabojago_server/repository/article/AccompanyArticleRepositoryTest.java
+++ b/src/test/java/com/example/gabojago_server/repository/article/AccompanyArticleRepositoryTest.java
@@ -1,0 +1,61 @@
+package com.example.gabojago_server.repository.article;
+
+import com.example.gabojago_server.config.JpaConfig;
+import com.example.gabojago_server.model.article.AccompanyArticle;
+import com.example.gabojago_server.model.member.Member;
+import com.example.gabojago_server.repository.member.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDate;
+
+@DataJpaTest
+@Import(JpaConfig.class)
+class AccompanyArticleRepositoryTest {
+
+    @Autowired
+    private AccompanyRepository accompanyRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("AccompanyArticle Entity 테스트")
+    public void AccompanyEntitySaveTest() throws Exception {
+        // given
+        Member member = stubMember();
+        memberRepository.save(member);
+
+        AccompanyArticle accompanyArticle = AccompanyArticle.builder()
+                .title("test title")
+                .content("test content")
+                .startDate(LocalDate.of(2023, 5, 9))
+                .endDate(LocalDate.of(2023, 5, 12))
+                .recruitNumber(4)
+                .region("서울")
+                .writer(member)
+                .build();
+        // when
+
+        accompanyRepository.save(accompanyArticle);
+
+        // then
+
+        Assertions.assertThat(accompanyArticle.getId()).isNotNull();
+
+    }
+
+    private Member stubMember() {
+        return Member.builder()
+                .name("test name")
+                .email("test@test.com")
+                .birth("2023-04-06")
+                .nickname("test Nickname")
+                .build();
+    }
+
+}

--- a/src/test/java/com/example/gabojago_server/repository/articlecomment/ArticleCommentRepositoryTest.java
+++ b/src/test/java/com/example/gabojago_server/repository/articlecomment/ArticleCommentRepositoryTest.java
@@ -1,0 +1,75 @@
+package com.example.gabojago_server.repository.articlecomment;
+
+import com.example.gabojago_server.config.JpaConfig;
+import com.example.gabojago_server.model.article.AccompanyArticle;
+import com.example.gabojago_server.model.articlecomment.ArticleComment;
+import com.example.gabojago_server.model.member.Member;
+import com.example.gabojago_server.repository.article.AccompanyRepository;
+import com.example.gabojago_server.repository.member.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDate;
+
+@DataJpaTest
+@Import(JpaConfig.class)
+class ArticleCommentRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private AccompanyRepository accompanyRepository;
+
+    @Autowired
+    private ArticleCommentRepository articleCommentRepository;
+
+    @Test
+    @DisplayName("articleComment Save Test")
+    public void articleCommentEntitySaveTest() throws Exception {
+        // given
+        Member writer = stubMember();
+        memberRepository.save(writer);
+        AccompanyArticle accompanyArticle = stubAccompany(writer);
+        accompanyRepository.save(accompanyArticle);
+
+        ArticleComment articleComment = ArticleComment.builder()
+                .article(accompanyArticle)
+                .content("test content")
+                .writer(writer)
+                .build();
+
+        // when
+        articleCommentRepository.save(articleComment);
+
+        // then
+        Assertions.assertThat(articleComment.getId()).isNotNull();
+    }
+
+
+    private AccompanyArticle stubAccompany(Member writer) {
+        return AccompanyArticle.builder()
+                .title("test title")
+                .content("test content")
+                .startDate(LocalDate.of(2023, 5, 9))
+                .endDate(LocalDate.of(2023, 5, 12))
+                .recruitNumber(4)
+                .region("서울")
+                .writer(writer)
+                .build();
+    }
+
+    private Member stubMember() {
+        return Member.builder()
+                .name("test name")
+                .email("test@test.com")
+                .birth("2023-04-06")
+                .nickname("test Nickname")
+                .build();
+    }
+
+}


### PR DESCRIPTION
### 관련 이슈 번호
#6 

### 변경 사항

- 동행 게시글 , 커뮤니티 , QnA 등 모두 게시글 성격을 가질 것으로 예상하고 Article 객체를 부모 클래스로 생성
- 동행 게시글 Entity 가 Article 을 상속받고 추가 내용을 필드에 정의함.
- ArticleComment Entity 정의 
- Repository 정의
- 간단한 Save 테스트

### 리뷰 시 주의사항, 기타사항
[ERD](https://www.notion.so/ERD-451f2e3e4d284d39b21c04c0a39f5b10) 를 참고해주세요
