### PR TITLE
feat:[#8] 동행 게시글 및 댓글 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,5 @@ out/
 .idea\
 .gradle\
 application.properties
-application.yml
+application.ymlapplication-oauth.properties
+application-oauth.properties

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,14 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.9'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10" //querydsl
 }
 
 group = 'com.example'
@@ -29,6 +36,10 @@ dependencies {
     //validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    //QueryDsl
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
@@ -44,4 +55,38 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+//querydsl 사용 경로
+def querydslDir = "$buildDir/generated/querydsl"
+
+//querydsl 사용 설정
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+
+// build 시 사용할 sourceSet
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+// compileClasspath와 annotationProcessor 상속
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    querydsl.extendsFrom compileClasspath
+}
+
+//feature/improve-all
+// querydsl 컴파일 시 사용할 옵션.
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
+}
+
+//feature/improve-all
+// QType 정리
+clean {
+    delete file(querydslDir)
 }

--- a/src/main/java/com/example/gabojago_server/config/JpaConfig.java
+++ b/src/main/java/com/example/gabojago_server/config/JpaConfig.java
@@ -1,9 +1,22 @@
 package com.example.gabojago_server.config;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 
 @EnableJpaAuditing
 @Configuration
 public class JpaConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory queryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
 }

--- a/src/main/java/com/example/gabojago_server/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/gabojago_server/config/WebSecurityConfig.java
@@ -40,6 +40,7 @@ public class WebSecurityConfig {
                 .antMatchers("/auth/login").permitAll()
                 .antMatchers("/login/**").permitAll()
                 .antMatchers("/oauth2/**").permitAll()
+                .antMatchers("/accompany/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .apply(new JwtSecurityConfig(jwtTokenProvider));

--- a/src/main/java/com/example/gabojago_server/dto/request/article/AccompanyRequestDto.java
+++ b/src/main/java/com/example/gabojago_server/dto/request/article/AccompanyRequestDto.java
@@ -1,0 +1,20 @@
+package com.example.gabojago_server.dto.request.article;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class AccompanyRequestDto {
+    private String title;
+
+    private String content;
+
+    private String region;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    private int recruitNumber;
+}

--- a/src/main/java/com/example/gabojago_server/dto/request/comment/CommentRequestDto.java
+++ b/src/main/java/com/example/gabojago_server/dto/request/comment/CommentRequestDto.java
@@ -1,0 +1,8 @@
+package com.example.gabojago_server.dto.request.comment;
+
+import lombok.Getter;
+
+@Getter
+public class CommentRequestDto {
+    private String content;
+}

--- a/src/main/java/com/example/gabojago_server/dto/request/member/ChangePhoneRequestDto.java
+++ b/src/main/java/com/example/gabojago_server/dto/request/member/ChangePhoneRequestDto.java
@@ -17,6 +17,6 @@ public class ChangePhoneRequestDto {
     private String email;
 
     @NotBlank(message = "핸드폰번호는 필수 입력 값입니다.")
-    @Pattern(regexp = "^[0-9]+-[0-9]+-[0-9]$", message = "번호 형식이 올바르지 않습니다.")
+    @Pattern(regexp = "^[0-9]{3}+-[0-9]{4}+-[0-9]{4}$", message = "번호 형식이 올바르지 않습니다.")
     private String phone;
 }

--- a/src/main/java/com/example/gabojago_server/dto/response/article/AccompanyResponseDto.java
+++ b/src/main/java/com/example/gabojago_server/dto/response/article/AccompanyResponseDto.java
@@ -1,0 +1,52 @@
+package com.example.gabojago_server.dto.response.article;
+
+import com.example.gabojago_server.model.article.AccompanyArticle;
+import com.example.gabojago_server.model.member.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AccompanyResponseDto {
+    private Long id;
+
+    private Member writer;
+
+    private String title;
+
+    private String content;
+
+    private int review;
+
+    private String region;
+
+    private String startDate;
+
+    private String endDate;
+
+    private int recruitMember;
+
+    private boolean isWritten;
+
+    public static AccompanyResponseDto of(AccompanyArticle article, boolean isWritten) {
+        return AccompanyResponseDto.builder()
+                .id(article.getId())
+                .writer(article.getWriter())
+                .title(article.getTitle())
+                .content(article.getContent())
+                .review(article.getReview())
+                .region(article.getRegion())
+                .startDate(article.getStartDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                .endDate(article.getEndDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                .recruitMember(article.getRecruitNumber())
+                .isWritten(isWritten)
+                .build();
+
+    }
+}

--- a/src/main/java/com/example/gabojago_server/dto/response/article/PageAccompanyResponseDto.java
+++ b/src/main/java/com/example/gabojago_server/dto/response/article/PageAccompanyResponseDto.java
@@ -1,0 +1,44 @@
+package com.example.gabojago_server.dto.response.article;
+
+import com.example.gabojago_server.model.article.AccompanyArticle;
+import com.example.gabojago_server.model.member.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@Builder
+public class PageAccompanyResponseDto {
+    private Long id;
+
+    private Member writer;
+
+    private String title;
+
+    private String content;
+
+    private int review;
+
+    private String region;
+
+    private String startDate;
+
+    private String endDate;
+
+    private int recruitMember;
+
+    public static PageAccompanyResponseDto of(AccompanyArticle article) {
+        return PageAccompanyResponseDto.builder()
+                .id(article.getId())
+                .writer(article.getWriter())
+                .title(article.getTitle())
+                .content(article.getContent())
+                .review(article.getReview())
+                .region(article.getRegion())
+                .startDate(article.getStartDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                .endDate(article.getEndDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                .recruitMember(article.getRecruitNumber())
+                .build();
+    }
+}

--- a/src/main/java/com/example/gabojago_server/dto/response/comment/CommentResponseDto.java
+++ b/src/main/java/com/example/gabojago_server/dto/response/comment/CommentResponseDto.java
@@ -1,0 +1,30 @@
+package com.example.gabojago_server.dto.response.comment;
+
+import com.example.gabojago_server.model.articlecomment.ArticleComment;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CommentResponseDto {
+    private Long commentId;
+
+    private String writerNickname;
+
+    private String content;
+
+    private boolean isWritten;
+
+    public static CommentResponseDto of(ArticleComment comment, boolean isWritten) {
+        return CommentResponseDto.builder()
+                .commentId(comment.getId())
+                .writerNickname(comment.getWriter().getNickname())
+                .content(comment.getContent())
+                .isWritten(isWritten)
+                .build();
+    }
+}

--- a/src/main/java/com/example/gabojago_server/model/article/AccompanyArticle.java
+++ b/src/main/java/com/example/gabojago_server/model/article/AccompanyArticle.java
@@ -1,7 +1,10 @@
 package com.example.gabojago_server.model.article;
 
 import com.example.gabojago_server.model.member.Member;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
@@ -26,17 +29,31 @@ public class AccompanyArticle extends Article {
 
     private int recruitNumber; // 모집인원
 
-    @Builder
-    public AccompanyArticle(Member writer, String title,
-                            String content, String region,
-                            LocalDate startDate, LocalDate endDate,
-                            int recruitNumber) {
-        this.writer = writer;
-        this.title = title;
-        this.content = content;
-        this.region = region;
-        this.startDate = startDate;
-        this.endDate = endDate;
-        this.recruitNumber = recruitNumber;
+    public static AccompanyArticle createAccompanyArticle(Member writer, String title,
+                                                          String content, int review, String region,
+                                                          LocalDate startDate, LocalDate endDate,
+                                                          int recruitNumber) {
+        AccompanyArticle article = new AccompanyArticle();
+        article.writer = writer;
+        article.title = title;
+        article.content = content;
+        article.review = review;
+        article.region = region;
+        article.startDate = startDate;
+        article.endDate = endDate;
+        article.recruitNumber = recruitNumber;
+        return article;
+    }
+
+    public static AccompanyArticle update(AccompanyArticle article, String title, String content, String region,
+                                          LocalDate startDate, LocalDate endDate,
+                                          int recruitNumber) {
+        article.title = title;
+        article.content = content;
+        article.region = region;
+        article.startDate = startDate;
+        article.endDate = endDate;
+        article.recruitNumber = recruitNumber;
+        return article;
     }
 }

--- a/src/main/java/com/example/gabojago_server/model/article/Article.java
+++ b/src/main/java/com/example/gabojago_server/model/article/Article.java
@@ -1,11 +1,14 @@
 package com.example.gabojago_server.model.article;
 
+import com.example.gabojago_server.model.articlecomment.ArticleComment;
 import com.example.gabojago_server.model.common.BaseTimeEntity;
 import com.example.gabojago_server.model.member.Member;
 import lombok.Getter;
 import lombok.ToString;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 @Entity
@@ -18,7 +21,7 @@ public abstract class Article extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     protected Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
     protected Member writer;
 
     @Column(nullable = false)
@@ -28,6 +31,13 @@ public abstract class Article extends BaseTimeEntity {
     protected String content; // 내용
 
     protected int review; //조회수
+
+    @OneToMany(mappedBy = "article", cascade = CascadeType.REMOVE)
+    protected List<ArticleComment> commentList = new ArrayList<>();
+
+    public void reviewCountUp() {
+        this.review++;
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/com/example/gabojago_server/model/articlecomment/ArticleComment.java
+++ b/src/main/java/com/example/gabojago_server/model/articlecomment/ArticleComment.java
@@ -34,6 +34,11 @@ public class ArticleComment extends BaseTimeEntity {
         this.content = content;
     }
 
+    public static ArticleComment update(ArticleComment comment, String content) {
+        comment.content = content;
+        return comment;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/example/gabojago_server/repository/article/ArticleRepository.java
+++ b/src/main/java/com/example/gabojago_server/repository/article/ArticleRepository.java
@@ -2,6 +2,8 @@ package com.example.gabojago_server.repository.article;
 
 import com.example.gabojago_server.model.article.AccompanyArticle;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
-public interface AccompanyRepository extends JpaRepository<AccompanyArticle, Long> {
+@Repository
+public interface ArticleRepository extends JpaRepository<AccompanyArticle, Long>, ArticleRepositoryCustom {
 }

--- a/src/main/java/com/example/gabojago_server/repository/article/ArticleRepositoryCustom.java
+++ b/src/main/java/com/example/gabojago_server/repository/article/ArticleRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.example.gabojago_server.repository.article;
+
+import com.example.gabojago_server.dto.response.article.PageAccompanyResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ArticleRepositoryCustom {
+    Page<PageAccompanyResponseDto> searchAll(Pageable pageable);
+}

--- a/src/main/java/com/example/gabojago_server/repository/article/ArticleRepositoryImpl.java
+++ b/src/main/java/com/example/gabojago_server/repository/article/ArticleRepositoryImpl.java
@@ -1,0 +1,43 @@
+package com.example.gabojago_server.repository.article;
+
+import com.example.gabojago_server.dto.response.article.PageAccompanyResponseDto;
+import com.example.gabojago_server.model.article.AccompanyArticle;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.example.gabojago_server.model.article.QAccompanyArticle.accompanyArticle;
+
+@Repository
+@RequiredArgsConstructor
+public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<PageAccompanyResponseDto> searchAll(Pageable pageable) {
+        List<AccompanyArticle> articles = jpaQueryFactory
+                .selectFrom(accompanyArticle)
+                .orderBy(accompanyArticle.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        List<PageAccompanyResponseDto> pages = articles
+                .stream()
+                .map(PageAccompanyResponseDto::of)
+                .collect(Collectors.toList());
+
+        int totalSize = jpaQueryFactory
+                .selectFrom(accompanyArticle)
+                .fetch()
+                .size();
+
+        return new PageImpl<>(pages, pageable, totalSize);
+    }
+}

--- a/src/main/java/com/example/gabojago_server/repository/articlecomment/ArticleCommentRepository.java
+++ b/src/main/java/com/example/gabojago_server/repository/articlecomment/ArticleCommentRepository.java
@@ -1,7 +1,13 @@
 package com.example.gabojago_server.repository.articlecomment;
 
+import com.example.gabojago_server.model.article.Article;
 import com.example.gabojago_server.model.articlecomment.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+@Repository
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
+    List<ArticleComment> findAllByArticle(Article article);
 }

--- a/src/main/java/com/example/gabojago_server/service/article/AccompanyService.java
+++ b/src/main/java/com/example/gabojago_server/service/article/AccompanyService.java
@@ -1,0 +1,97 @@
+package com.example.gabojago_server.service.article;
+
+import com.example.gabojago_server.config.SecurityUtil;
+import com.example.gabojago_server.dto.response.article.AccompanyResponseDto;
+import com.example.gabojago_server.dto.response.article.PageAccompanyResponseDto;
+import com.example.gabojago_server.model.article.AccompanyArticle;
+import com.example.gabojago_server.model.member.Member;
+import com.example.gabojago_server.repository.article.ArticleRepository;
+import com.example.gabojago_server.repository.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AccompanyService {
+    private final ArticleRepository articleRepository;
+    private final MemberRepository memberRepository;
+
+    public AccompanyResponseDto oneAccompany(Long id) {
+        AccompanyArticle article = articleRepository.findById(id).orElseThrow(() -> new RuntimeException("글이 없습니다."));
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getPrincipal() == "anonymousUser") {
+            article.reviewCountUp();
+            return AccompanyResponseDto.of(article, false);
+        } else {
+            Member member = memberRepository.findById(Long.parseLong(authentication.getName())).orElseThrow();
+            boolean isWritten = article.getWriter().equals(member);
+            article.reviewCountUp();
+            return AccompanyResponseDto.of(article, isWritten);
+        }
+    }
+
+    public List<PageAccompanyResponseDto> allAccompany() {
+        List<AccompanyArticle> accompanyArticles = articleRepository.findAll();
+        return accompanyArticles.stream()
+                .map(PageAccompanyResponseDto::of)
+                .collect(Collectors.toList());
+    }
+
+    public Page<PageAccompanyResponseDto> pageAccompany(int pageNum) {
+        return articleRepository.searchAll(PageRequest.of(pageNum - 1, 20));
+    }
+
+    @Transactional
+    public AccompanyResponseDto postAccompany(String title, String content,
+                                              String region, LocalDate startDate, LocalDate endDate,
+                                              int recruitNumber) {
+        Member writer = isMember();
+        AccompanyArticle article = AccompanyArticle.createAccompanyArticle(writer, title, content, 0, region,
+                startDate, endDate, recruitNumber);
+        return AccompanyResponseDto.of(articleRepository.save(article), true);
+    }
+
+    public Member isMember() {
+        return memberRepository.findById(SecurityUtil.getCurrentMemberIdx())
+                .orElseThrow(() -> new RuntimeException("로그인 유저 정보가 없습니다"));
+    }
+
+    public AccompanyArticle authorizationAccompanyWriter(Long id) {
+        Member member = isMember();
+        AccompanyArticle article = articleRepository.findById(id).orElseThrow(() -> new RuntimeException("글이 없습니다."));
+        if (!article.getWriter().equals(member)) {
+            throw new RuntimeException("로그인한 유저와 작성 유저가 같지 않습니다.");
+        }
+        return article;
+    }
+
+    @Transactional
+    public AccompanyResponseDto changeAccompanyArticle(Long id, String title, String content,
+                                                       String region, LocalDate startDate,
+                                                       LocalDate endDate, int recruitMember) {
+        AccompanyArticle article = authorizationAccompanyWriter(id);
+        return AccompanyResponseDto.of(
+                articleRepository.save(
+                        AccompanyArticle.update(
+                                article, title, content, region, startDate, endDate, recruitMember
+                        )
+                ), true
+        );
+    }
+
+    @Transactional
+    public void deleteAccompanyArticle(Long id) {
+        AccompanyArticle article = authorizationAccompanyWriter(id);
+        articleRepository.delete(article);
+    }
+}

--- a/src/main/java/com/example/gabojago_server/service/comment/CommentService.java
+++ b/src/main/java/com/example/gabojago_server/service/comment/CommentService.java
@@ -1,0 +1,117 @@
+package com.example.gabojago_server.service.comment;
+
+import com.example.gabojago_server.config.SecurityUtil;
+import com.example.gabojago_server.dto.response.comment.CommentResponseDto;
+import com.example.gabojago_server.model.article.Article;
+import com.example.gabojago_server.model.articlecomment.ArticleComment;
+import com.example.gabojago_server.model.member.Member;
+import com.example.gabojago_server.repository.article.ArticleRepository;
+import com.example.gabojago_server.repository.articlecomment.ArticleCommentRepository;
+import com.example.gabojago_server.repository.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CommentService {
+    private final ArticleRepository articleRepository;
+    private final MemberRepository memberRepository;
+    private final ArticleCommentRepository commentRepository;
+
+    public List<CommentResponseDto> getAllComments(Long articleId) {
+        Article article = articleRepository.findById(articleId).orElseThrow(() -> new RuntimeException("댓글이 없습니다."));
+        List<ArticleComment> comments = commentRepository.findAllByArticle(article);
+
+        if (comments.isEmpty())
+            return Collections.emptyList();
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getPrincipal() == "anonymousUser") {
+            return comments.stream()
+                    .map(comment -> CommentResponseDto.of(comment, false))
+                    .collect(Collectors.toList());
+        } else {
+            Member member = memberRepository.findById(Long.parseLong(authentication.getName()))
+                    .orElseThrow();
+            Map<Boolean, List<ArticleComment>> collect = comments.stream()
+                    .collect(
+                            Collectors.partitioningBy(
+                                    comment -> comment.getWriter().equals(member)
+                            )
+                    );
+
+            //로그인 유저가 작성한 comment들
+            List<CommentResponseDto> trueCollect = collect.get(true).stream()
+                    .map(t -> CommentResponseDto.of(t, true))
+                    .collect(Collectors.toList());
+
+            //로그인 유저가 작성하지 않은 comment들
+            List<CommentResponseDto> falseCollect = collect.get(false).stream()
+                    .map(f -> CommentResponseDto.of(f, false))
+                    .collect(Collectors.toList());
+
+            //둘 다 합쳐서 return
+            return Stream.concat(trueCollect.stream(), falseCollect.stream())
+                    .sorted(Comparator.comparing(CommentResponseDto::getCommentId))
+                    .collect(Collectors.toList());
+        }
+    }
+
+    @Transactional
+    public CommentResponseDto createComment(Long articleId, String content) {
+        Member member = memberRepository.findById(
+                        SecurityUtil.getCurrentMemberIdx())
+                .orElseThrow(() -> new RuntimeException("로그인 유저 정보가 없습니다."));
+        Article article = articleRepository.findById(articleId)
+                .orElseThrow(() -> new RuntimeException("글이 없습니다."));
+
+        ArticleComment comment = ArticleComment.builder()
+                .content(content)
+                .article(article)
+                .writer(member)
+                .build();
+
+        return CommentResponseDto.of(commentRepository.save(comment), true);
+    }
+
+    @Transactional
+    public CommentResponseDto changeComment(Long commentId, String content) {
+        Member member = memberRepository.findById(
+                        SecurityUtil.getCurrentMemberIdx())
+                .orElseThrow(() -> new RuntimeException("로그인 정보가 없습니다."));
+        ArticleComment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new RuntimeException("댓글이 없습니다."));
+
+        if (!comment.getWriter().equals(member)) {
+            throw new RuntimeException("댓글 작성자가 아닙니다.");
+        }
+        return CommentResponseDto.of(
+                commentRepository.save(ArticleComment.update(comment, content)), true
+        );
+    }
+
+    @Transactional
+    public void removeComment(Long commentId) {
+        Member member = memberRepository.findById(
+                        SecurityUtil.getCurrentMemberIdx())
+                .orElseThrow(() -> new RuntimeException("로그인 정보가 없습니다."));
+        ArticleComment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new RuntimeException("댓글이 없습니다."));
+        if (!comment.getWriter().equals(member)) {
+            throw new RuntimeException("댓글 작성자가 아닙니다.");
+        }
+        commentRepository.delete(comment);
+    }
+}

--- a/src/main/java/com/example/gabojago_server/web/controller/article/AccompanyController.java
+++ b/src/main/java/com/example/gabojago_server/web/controller/article/AccompanyController.java
@@ -1,0 +1,56 @@
+package com.example.gabojago_server.web.controller.article;
+
+import com.example.gabojago_server.dto.request.article.AccompanyRequestDto;
+import com.example.gabojago_server.dto.response.article.AccompanyResponseDto;
+import com.example.gabojago_server.dto.response.article.PageAccompanyResponseDto;
+import com.example.gabojago_server.service.article.AccompanyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/accompany")
+public class AccompanyController {
+    private final AccompanyService accompanyService;
+
+    @GetMapping("/posts")
+    public ResponseEntity<List<PageAccompanyResponseDto>> getArticleList() {
+        return ResponseEntity.ok(accompanyService.allAccompany());
+    }
+
+    @GetMapping("/page/{pageNum}")
+    public ResponseEntity<Page<PageAccompanyResponseDto>> pageAccompany(@PathVariable(value = "pageNum") int pageNum) {
+        return ResponseEntity.ok(accompanyService.pageAccompany(pageNum));
+    }
+
+    @GetMapping("/posts/{id}")
+    public ResponseEntity<AccompanyResponseDto> getOneAccompany(@PathVariable(value = "id") Long id) {
+        return ResponseEntity.ok(accompanyService.oneAccompany(id));
+    }
+
+    @PostMapping("/post")
+    public ResponseEntity<AccompanyResponseDto> createAccompanyArticle(@RequestBody AccompanyRequestDto requestDto) {
+        return ResponseEntity.ok(accompanyService.postAccompany(requestDto.getTitle(),
+                requestDto.getContent(), requestDto.getRegion(), requestDto.getStartDate(),
+                requestDto.getEndDate(), requestDto.getRecruitNumber()));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<AccompanyResponseDto> changeAccompanyArticle(@PathVariable(value = "id") Long id, @RequestBody AccompanyRequestDto requestDto) {
+        return ResponseEntity.ok(accompanyService.changeAccompanyArticle(
+                id, requestDto.getTitle(), requestDto.getContent(), requestDto.getRegion(),
+                requestDto.getStartDate(), requestDto.getEndDate(), requestDto.getRecruitNumber()
+        ));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> deleteAccompanyArticle(@PathVariable(value = "id") Long id) {
+        accompanyService.deleteAccompanyArticle(id);
+        return ResponseEntity.ok(new String("Success".getBytes(), StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/com/example/gabojago_server/web/controller/comment/CommentController.java
+++ b/src/main/java/com/example/gabojago_server/web/controller/comment/CommentController.java
@@ -1,0 +1,40 @@
+package com.example.gabojago_server.web.controller.comment;
+
+import com.example.gabojago_server.dto.request.comment.CommentRequestDto;
+import com.example.gabojago_server.dto.response.comment.CommentResponseDto;
+import com.example.gabojago_server.service.comment.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/comment")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<List<CommentResponseDto>> getAllComments(@PathVariable(value = "postId") Long postId) {
+        return ResponseEntity.ok(commentService.getAllComments(postId));
+    }
+
+    @PostMapping("/{postId}")
+    public ResponseEntity<CommentResponseDto> postComment(@PathVariable(value = "postId") Long postId, @RequestBody CommentRequestDto request) {
+        return ResponseEntity.ok(commentService.createComment(postId, request.getContent()));
+    }
+
+    @PutMapping("/{commentId}")
+    public ResponseEntity<CommentResponseDto> changeComment(@PathVariable(value = "commentId") Long commentId, @RequestBody CommentRequestDto request) {
+        return ResponseEntity.ok(commentService.changeComment(commentId, request.getContent()));
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<String> deleteComment(@PathVariable(value = "commentId") Long commentId) {
+        commentService.removeComment(commentId);
+        return ResponseEntity.ok(new String("Success".getBytes(), StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/com/example/gabojago_server/web/controller/member/MemberController.java
+++ b/src/main/java/com/example/gabojago_server/web/controller/member/MemberController.java
@@ -1,8 +1,8 @@
 package com.example.gabojago_server.web.controller.member;
 
+import com.example.gabojago_server.dto.request.member.ChangeNickNameRequestDto;
 import com.example.gabojago_server.dto.request.member.ChangePasswordRequestDto;
 import com.example.gabojago_server.dto.request.member.ChangePhoneRequestDto;
-import com.example.gabojago_server.dto.request.member.MemberRequestDto;
 import com.example.gabojago_server.dto.response.member.MemberResponseDto;
 import com.example.gabojago_server.service.member.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +27,7 @@ public class MemberController {
     }
 
     @PostMapping("/nickname")
-    public ResponseEntity<MemberResponseDto> setMemberNickname(@RequestBody @Valid MemberRequestDto request) {
+    public ResponseEntity<MemberResponseDto> setMemberNickname(@RequestBody @Valid ChangeNickNameRequestDto request) {
         return ResponseEntity.ok(memberService.changeNickname(request.getEmail(), request.getNickname()));
     }
 

--- a/src/test/java/com/example/gabojago_server/repository/article/AccompanyArticleRepositoryTest.java
+++ b/src/test/java/com/example/gabojago_server/repository/article/AccompanyArticleRepositoryTest.java
@@ -18,7 +18,7 @@ import java.time.LocalDate;
 class AccompanyArticleRepositoryTest {
 
     @Autowired
-    private AccompanyRepository accompanyRepository;
+    private ArticleRepository articleRepository;
 
     @Autowired
     private MemberRepository memberRepository;
@@ -41,7 +41,7 @@ class AccompanyArticleRepositoryTest {
                 .build();
         // when
 
-        accompanyRepository.save(accompanyArticle);
+        articleRepository.save(accompanyArticle);
 
         // then
 

--- a/src/test/java/com/example/gabojago_server/repository/articlecomment/ArticleCommentRepositoryTest.java
+++ b/src/test/java/com/example/gabojago_server/repository/articlecomment/ArticleCommentRepositoryTest.java
@@ -4,7 +4,7 @@ import com.example.gabojago_server.config.JpaConfig;
 import com.example.gabojago_server.model.article.AccompanyArticle;
 import com.example.gabojago_server.model.articlecomment.ArticleComment;
 import com.example.gabojago_server.model.member.Member;
-import com.example.gabojago_server.repository.article.AccompanyRepository;
+import com.example.gabojago_server.repository.article.ArticleRepository;
 import com.example.gabojago_server.repository.member.MemberRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -23,7 +23,7 @@ class ArticleCommentRepositoryTest {
     private MemberRepository memberRepository;
 
     @Autowired
-    private AccompanyRepository accompanyRepository;
+    private ArticleRepository articleRepository;
 
     @Autowired
     private ArticleCommentRepository articleCommentRepository;
@@ -35,7 +35,7 @@ class ArticleCommentRepositoryTest {
         Member writer = stubMember();
         memberRepository.save(writer);
         AccompanyArticle accompanyArticle = stubAccompany(writer);
-        accompanyRepository.save(accompanyArticle);
+        articleRepository.save(accompanyArticle);
 
         ArticleComment articleComment = ArticleComment.builder()
                 .article(accompanyArticle)


### PR DESCRIPTION
### 관련 이슈 번호
#8

### 변경 사항
- Article Entity에 조회수 증가 로직/댓글 리스트 추가
- Article Entity의 작성자(member)의 fetch type을 디폴트 값인 eager로 변경(lazy 사용시 에러 발생)
- AccompanyArticle Entity에 생성자 빌더 패턴 대신 정적 팩토리 메서드 사용
- AccompanyArticle Entity에 게시글 수정 위한 update 메서드 추가
- AccompanyArticle Entity 생성 시 조회수 0으로 초기화
- 페이징 처리 위한 quderydsl 사용
- querydsl 사용 위해 JpaConfig에 EntityManager 설정(설정 미적용 시 에러 발생)
- 페이징 처리 위해 pageResponseDto, 사용자 정의 게시글 repository 인터페이스, 구현체 생성
- Repository의 기능은 카테고리 상관없이 동일할 것으로 판단되어 AccompanyRepository에서 ArticleRepository로 이름 변경
- 로그인하지 않아도 가능한 기능들이 존재하므로 WebSecurityConfig에 "/accompany/**" 추가
- 닉네임 변경 시 ChangeNicknameRequestDto 사용하도록 변경
- 핸드폰 번호 변경 시 phone 필드 validation regex 변경
-  동행 게시글 작성, 수정, 삭제, 조회 기능 구현
- 게시글의 댓글 작성, 수정, 삭제, 조회 기능 구현

### 리뷰 시 주의사항, 기타사항
- 게시글의 Repository 기능은 다 동일할 것으로 판단되어 ArticleRepository로 통일하였습니다. 확인 부탁드려요!
- accompany와 comment의 endpoint에는 /api로 시작되도록 하였는데, 추후에 auth와 members도 /api로 시작되도록 변경할 것 같습니다.
- 게시글 목록은 페이징 처리를 하였는데 댓글에 대해서는 페이징처리하지 않았습니다. 필요하다면 추후에 적용할 것 같아요.
- 구현하다보니 회원 기능에서 닉네임, 폰번호, 이메일을 변경할 때 이메일로 회원을 찾고 변경되도록 로직을 구성했던 걸 발견했습니다. 이 부분도 추후에 이슈를 따로 파서 email 대신 securityutil을 이용한 authentication으로 확인하는 것으로 변경할 것 같습니다.
- 조회수 기능에 대해서는 사용자에 대핸 중복 무한정 방지 없이 일단 게시글 상세 정보 조회시마다 무조건 1씩 증가하도록 하였습니다. 만약 중복 방지가 필요하다면 상세 조건에 대해 의논이 필요할 것 같습니다.
- 답댓글 기능을 아직 구현하지 않았는데, 만약 구현할 계획이라면 댓글 삭제 시 답댓글도 같이 삭제할 지, 댓글만 '삭제된 댓글입니다' 형식으로 처리하고 답댓글을 남겨둘 지에 대해 의논이 필요할 것 같습니다.

이해되지 않거나 궁금한 점 있으시면 연락주세요!!