### PR TITLE
feat : [#14] 커뮤니티 글 및 좋아요 기능 구현

### DIFF
--- a/src/main/java/com/example/gabojago_server/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/gabojago_server/config/WebSecurityConfig.java
@@ -46,8 +46,9 @@ public class WebSecurityConfig {
                 .antMatchers("/auth/login").permitAll()
                 .antMatchers("/login/**").permitAll()
                 .antMatchers("/oauth2/**").permitAll()
-                .antMatchers("/accompany/**").permitAll()
-                .antMatchers("/qna/**").permitAll()
+                .antMatchers("/api/accompany/**").permitAll()
+                .antMatchers("/api/qna/**").permitAll()
+                .antMatchers("/api/articles/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .apply(new JwtSecurityConfig(jwtTokenProvider));

--- a/src/main/java/com/example/gabojago_server/dto/request/article/ArticleRequestDto.java
+++ b/src/main/java/com/example/gabojago_server/dto/request/article/ArticleRequestDto.java
@@ -1,0 +1,12 @@
+package com.example.gabojago_server.dto.request.article;
+
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class ArticleRequestDto {
+    String title;
+    String content;
+}

--- a/src/main/java/com/example/gabojago_server/dto/response/article/ArticleResponseDto.java
+++ b/src/main/java/com/example/gabojago_server/dto/response/article/ArticleResponseDto.java
@@ -1,0 +1,37 @@
+package com.example.gabojago_server.dto.response.article;
+
+
+import com.example.gabojago_server.model.article.Article;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class ArticleResponseDto {
+    private Long articleId;
+    private String nickname;
+    private String title;
+    private String content;
+    private int review;
+
+
+    @Builder
+    private ArticleResponseDto(Long articleId, String nickname, String title, String content, int review) {
+        this.articleId = articleId;
+        this.nickname = nickname;
+        this.title = title;
+        this.content = content;
+        this.review = review;
+    }
+
+    public static ArticleResponseDto from(Article article) {
+        return ArticleResponseDto.builder()
+                .articleId(article.getId())
+                .content(article.getContent())
+                .title(article.getTitle())
+                .review(article.getReview())
+                .nickname(article.getWriter().getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/example/gabojago_server/dto/response/like/LikeClickResponse.java
+++ b/src/main/java/com/example/gabojago_server/dto/response/like/LikeClickResponse.java
@@ -1,0 +1,12 @@
+package com.example.gabojago_server.dto.response.like;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LikeClickResponse {
+    private int likeNumber;
+}

--- a/src/main/java/com/example/gabojago_server/model/article/Article.java
+++ b/src/main/java/com/example/gabojago_server/model/article/Article.java
@@ -3,8 +3,8 @@ package com.example.gabojago_server.model.article;
 import com.example.gabojago_server.model.articlecomment.ArticleComment;
 import com.example.gabojago_server.model.common.BaseTimeEntity;
 import com.example.gabojago_server.model.member.Member;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.*;
+import org.springframework.util.StringUtils;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -16,7 +16,8 @@ import java.util.Objects;
 @Inheritance(strategy = InheritanceType.JOINED)
 @ToString(exclude = "writer")
 @Table(name = "articles")
-public abstract class Article extends BaseTimeEntity {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Article extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,6 +38,18 @@ public abstract class Article extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "article", cascade = CascadeType.REMOVE)
     protected List<ArticleComment> commentList = new ArrayList<>();
+
+    @Builder
+    public Article(Member writer, String title, String content) {
+        this.writer = writer;
+        this.title = title;
+        this.content = content;
+    }
+
+    public void edit(String title, String content) {
+        if (StringUtils.hasText(title)) this.title = title;
+        if (StringUtils.hasText(content)) this.content = content;
+    }
 
     public void reviewCountUp() {
         this.review++;

--- a/src/main/java/com/example/gabojago_server/model/like/LikeEntity.java
+++ b/src/main/java/com/example/gabojago_server/model/like/LikeEntity.java
@@ -1,0 +1,38 @@
+package com.example.gabojago_server.model.like;
+
+import com.example.gabojago_server.model.article.Article;
+import com.example.gabojago_server.model.common.BaseTimeEntity;
+import com.example.gabojago_server.model.member.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Table(name = "like_entity")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LikeEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "like_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id")
+    private Article article;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder
+    public LikeEntity(Article article, Member member) {
+        this.article = article;
+        this.member = member;
+    }
+}
+

--- a/src/main/java/com/example/gabojago_server/repository/article/article/ArticleRepository.java
+++ b/src/main/java/com/example/gabojago_server/repository/article/article/ArticleRepository.java
@@ -1,0 +1,14 @@
+package com.example.gabojago_server.repository.article.article;
+
+import com.example.gabojago_server.model.article.Article;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+
+    @Query("select a from Article a where a.id = :articleId and a.writer.id = :writerId")
+    Optional<Article> findByWriterAndArticle(@Param("writerId") Long writerId, @Param("articleId") Long articleId);
+}

--- a/src/main/java/com/example/gabojago_server/repository/like/LikeRepository.java
+++ b/src/main/java/com/example/gabojago_server/repository/like/LikeRepository.java
@@ -1,0 +1,18 @@
+package com.example.gabojago_server.repository.like;
+
+import com.example.gabojago_server.model.article.Article;
+import com.example.gabojago_server.model.like.LikeEntity;
+import com.example.gabojago_server.model.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface LikeRepository extends JpaRepository<LikeEntity, Long> {
+
+    Optional<LikeEntity> findByArticleAndMember(Article article, Member member);
+
+    @Query(" select count(*) from Article a where a = :article ")
+    Integer findByArticle(@Param("article") Article article);
+}

--- a/src/main/java/com/example/gabojago_server/service/article/ArticleService.java
+++ b/src/main/java/com/example/gabojago_server/service/article/ArticleService.java
@@ -1,0 +1,67 @@
+package com.example.gabojago_server.service.article;
+
+import com.example.gabojago_server.dto.response.article.ArticleResponseDto;
+import com.example.gabojago_server.model.article.Article;
+import com.example.gabojago_server.model.member.Member;
+import com.example.gabojago_server.repository.article.article.ArticleRepository;
+import com.example.gabojago_server.repository.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ArticleService {
+
+    private final ArticleRepository articleRepository;
+    private final MemberRepository memberRepository;
+
+    public Page<ArticleResponseDto> allArticle(Pageable pageable) {
+        return articleRepository.findAll(pageable).map(ArticleResponseDto::from);
+    }
+
+    public ArticleResponseDto oneArticle(Long writerId, Long articleId) {
+        return ArticleResponseDto.from(articleRepository
+                .findByWriterAndArticle(writerId, articleId)
+                .orElseThrow(IllegalStateException::new));
+    }
+
+    @Transactional
+    public ArticleResponseDto postArticle(Long writerId, String title, String content) {
+        Member writer = findWriter(writerId);
+        Article article = Article.builder()
+                .content(content)
+                .title(title)
+                .writer(writer)
+                .build();
+        return ArticleResponseDto.from(articleRepository.save(article));
+    }
+
+    @Transactional
+    public ArticleResponseDto changeArticle(Long writerId, Long articleId, String title, String content) {
+        Article article = findArticle(articleId);
+        Member writer = findWriter(writerId);
+        if (!article.getWriter().equals(writer)) throw new IllegalStateException();
+        article.edit(title, content);
+        return ArticleResponseDto.from(article);
+    }
+
+    public void deleteArticle(Long writerId, Long articleId) {
+        Article article = findArticle(articleId);
+        Member writer = findWriter(writerId);
+        if (!article.getWriter().equals(writer)) return;
+        articleRepository.delete(article);
+    }
+
+    private Member findWriter(Long writerId) {
+        return memberRepository.findById(writerId).orElseThrow(IllegalStateException::new);
+    }
+
+    private Article findArticle(Long articleId) {
+        return articleRepository.findById(articleId).orElseThrow(IllegalStateException::new);
+    }
+
+}

--- a/src/main/java/com/example/gabojago_server/service/like/LikeService.java
+++ b/src/main/java/com/example/gabojago_server/service/like/LikeService.java
@@ -1,0 +1,48 @@
+package com.example.gabojago_server.service.like;
+
+import com.example.gabojago_server.model.article.Article;
+import com.example.gabojago_server.model.like.LikeEntity;
+import com.example.gabojago_server.model.member.Member;
+import com.example.gabojago_server.repository.article.article.ArticleRepository;
+import com.example.gabojago_server.repository.like.LikeRepository;
+import com.example.gabojago_server.repository.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LikeService {
+    private final LikeRepository likeRepository;
+    private final ArticleRepository articleRepository;
+    private final MemberRepository memberRepository;
+
+
+    public void clickLike(Long articleId, Long memberId) {
+        Article article = getArticle(articleId);
+        Member member = getMember(memberId);
+
+        if (likeRepository.findByArticleAndMember(article, member).isPresent()) return;
+
+        likeRepository.save(LikeEntity.builder()
+                .article(article)
+                .member(member)
+                .build());
+    }
+
+    public int getLike(Long articleId) {
+        Article article = getArticle(articleId);
+        return likeRepository.findByArticle(article);
+    }
+
+
+    private Article getArticle(Long articleId) {
+        return articleRepository.findById(articleId).orElseThrow(IllegalStateException::new);
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(IllegalStateException::new);
+    }
+
+}

--- a/src/main/java/com/example/gabojago_server/web/controller/article/AccompanyController.java
+++ b/src/main/java/com/example/gabojago_server/web/controller/article/AccompanyController.java
@@ -1,6 +1,5 @@
 package com.example.gabojago_server.web.controller.article;
 
-import com.example.gabojago_server.config.SecurityUtil;
 import com.example.gabojago_server.dto.request.article.AccompanyRequestDto;
 import com.example.gabojago_server.dto.response.article.accompany.AccompanyResponseDto;
 import com.example.gabojago_server.dto.response.article.accompany.PageAccompanyResponseDto;
@@ -13,6 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.nio.charset.StandardCharsets;
+
+import static com.example.gabojago_server.config.SecurityUtil.getCurrentMemberIdx;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,19 +28,19 @@ public class AccompanyController {
 
     @GetMapping("/posts/{articleId}")
     public ResponseEntity<AccompanyResponseDto> getOneAccompany(@PathVariable(value = "articleId") Long articleId) {
-        return ResponseEntity.ok(accompanyService.oneAccompany(findMemberId(), articleId));
+        return ResponseEntity.ok(accompanyService.oneAccompany(getCurrentMemberIdx(), articleId));
     }
 
     @PostMapping("/post")
     public ResponseEntity<AccompanyResponseDto> createAccompanyArticle(@RequestBody AccompanyRequestDto requestDto) {
-        return ResponseEntity.ok(accompanyService.postAccompany(findMemberId(), requestDto.getTitle(),
+        return ResponseEntity.ok(accompanyService.postAccompany(getCurrentMemberIdx(), requestDto.getTitle(),
                 requestDto.getContent(), requestDto.getRegion(), requestDto.getStartDate(),
                 requestDto.getEndDate(), requestDto.getRecruitNumber()));
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<AccompanyResponseDto> changeAccompanyArticle(@PathVariable(value = "id") Long articleId, @RequestBody AccompanyRequestDto requestDto) {
-        return ResponseEntity.ok(accompanyService.changeAccompanyArticle(findMemberId(),
+        return ResponseEntity.ok(accompanyService.changeAccompanyArticle(getCurrentMemberIdx(),
                 articleId, requestDto.getTitle(), requestDto.getContent(), requestDto.getRegion(),
                 requestDto.getStartDate(), requestDto.getEndDate(), requestDto.getRecruitNumber()
         ));
@@ -47,11 +48,7 @@ public class AccompanyController {
 
     @DeleteMapping("/{id}")
     public ResponseEntity<String> deleteAccompanyArticle(@PathVariable(value = "id") Long articleId) {
-        accompanyService.deleteAccompanyArticle(findMemberId(), articleId);
+        accompanyService.deleteAccompanyArticle(getCurrentMemberIdx(), articleId);
         return ResponseEntity.ok(new String("Success".getBytes(), StandardCharsets.UTF_8));
-    }
-
-    private Long findMemberId() {
-        return SecurityUtil.getCurrentMemberIdx();
     }
 }

--- a/src/main/java/com/example/gabojago_server/web/controller/article/ArticleController.java
+++ b/src/main/java/com/example/gabojago_server/web/controller/article/ArticleController.java
@@ -1,0 +1,54 @@
+package com.example.gabojago_server.web.controller.article;
+
+
+import com.example.gabojago_server.dto.request.article.AccompanyRequestDto;
+import com.example.gabojago_server.dto.request.article.ArticleRequestDto;
+import com.example.gabojago_server.dto.response.article.ArticleResponseDto;
+import com.example.gabojago_server.service.article.ArticleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.nio.charset.StandardCharsets;
+
+import static com.example.gabojago_server.config.SecurityUtil.getCurrentMemberIdx;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/articles")
+public class ArticleController {
+
+    private final ArticleService articleService;
+
+    @GetMapping("/posts")
+    public ResponseEntity<Page<ArticleResponseDto>> getArticleList(@PageableDefault Pageable pageable) {
+        return ResponseEntity.ok(articleService.allArticle(pageable));
+    }
+
+    @GetMapping("/posts/{articleId}")
+    public ResponseEntity<ArticleResponseDto> getOneAccompany(@PathVariable(value = "articleId") Long articleId) {
+        return ResponseEntity.ok(articleService.oneArticle(getCurrentMemberIdx(), articleId));
+    }
+
+    @PostMapping("/post")
+    public ResponseEntity<ArticleResponseDto> createAccompanyArticle(@RequestBody ArticleRequestDto requestDto) {
+        return ResponseEntity.ok(articleService.postArticle(getCurrentMemberIdx(), requestDto.getTitle(), requestDto.getContent()));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ArticleResponseDto> changeAccompanyArticle(@PathVariable(value = "id") Long articleId, @RequestBody AccompanyRequestDto requestDto) {
+        return ResponseEntity.ok(articleService.changeArticle(getCurrentMemberIdx(),
+                articleId, requestDto.getTitle(), requestDto.getContent()));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> deleteAccompanyArticle(@PathVariable(value = "id") Long articleId) {
+        articleService.deleteArticle(getCurrentMemberIdx(), articleId);
+        return ResponseEntity.ok(new String("Success".getBytes(), StandardCharsets.UTF_8));
+    }
+
+
+}

--- a/src/main/java/com/example/gabojago_server/web/controller/article/QnaController.java
+++ b/src/main/java/com/example/gabojago_server/web/controller/article/QnaController.java
@@ -1,6 +1,5 @@
 package com.example.gabojago_server.web.controller.article;
 
-import com.example.gabojago_server.config.SecurityUtil;
 import com.example.gabojago_server.dto.request.article.QnaRequestDto;
 import com.example.gabojago_server.dto.response.article.qna.PageQnaResponseDto;
 import com.example.gabojago_server.dto.response.article.qna.QnaResponseDto;
@@ -13,6 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.nio.charset.StandardCharsets;
+
+import static com.example.gabojago_server.config.SecurityUtil.getCurrentMemberIdx;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,26 +28,23 @@ public class QnaController {
 
     @GetMapping("/posts/{articleId}")
     public ResponseEntity<QnaResponseDto> getOneQna(@PathVariable(value = "articleId") Long articleId) {
-        return ResponseEntity.ok(qnaService.oneQna(findMemberId(), articleId));
+        return ResponseEntity.ok(qnaService.oneQna(getCurrentMemberIdx(), articleId));
     }
 
     @PostMapping("/post")
     public ResponseEntity<QnaResponseDto> createQnaArticle(@RequestBody QnaRequestDto requestDto) {
-        return ResponseEntity.ok(qnaService.postQna(findMemberId(), requestDto.getTitle(), requestDto.getContent(), requestDto.isSelected()));
+        return ResponseEntity.ok(qnaService.postQna(getCurrentMemberIdx(), requestDto.getTitle(), requestDto.getContent(), requestDto.isSelected()));
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<QnaResponseDto> changeQnaArticle(@PathVariable(value = "id") Long articleId, @RequestBody QnaRequestDto requestDto) {
-        return ResponseEntity.ok(qnaService.changeQnaArticle(findMemberId(), articleId, requestDto.getTitle(), requestDto.getContent(), requestDto.isSelected()));
+        return ResponseEntity.ok(qnaService.changeQnaArticle(getCurrentMemberIdx(), articleId, requestDto.getTitle(), requestDto.getContent(), requestDto.isSelected()));
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<String> deleteQnaArticle(@PathVariable(value = "id") Long articleId) {
-        qnaService.deleteQnaArticle(findMemberId(), articleId);
+        qnaService.deleteQnaArticle(getCurrentMemberIdx(), articleId);
         return ResponseEntity.ok(new String("Success".getBytes(StandardCharsets.UTF_8)));
     }
 
-    private Long findMemberId() {
-        return SecurityUtil.getCurrentMemberIdx();
-    }
 }

--- a/src/main/java/com/example/gabojago_server/web/controller/like/LikeController.java
+++ b/src/main/java/com/example/gabojago_server/web/controller/like/LikeController.java
@@ -1,0 +1,29 @@
+package com.example.gabojago_server.web.controller.like;
+
+import com.example.gabojago_server.config.SecurityUtil;
+import com.example.gabojago_server.dto.response.like.LikeClickResponse;
+import com.example.gabojago_server.service.like.LikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.nio.charset.StandardCharsets;
+
+@RestController
+@RequestMapping("/api/like")
+@RequiredArgsConstructor
+public class LikeController {
+    private final LikeService likeService;
+
+    @PostMapping("/{articleId}")
+    public ResponseEntity<String> like(@PathVariable Long articleId) {
+        likeService.clickLike(articleId, SecurityUtil.getCurrentMemberIdx());
+        return ResponseEntity.ok(new String("Success".getBytes(), StandardCharsets.UTF_8));
+    }
+
+    @GetMapping("/{articleId}")
+    public ResponseEntity<LikeClickResponse> getLikeNumber(@PathVariable Long articleId) {
+        int likeNumber = likeService.getLike(articleId);
+        return ResponseEntity.ok(new LikeClickResponse(likeNumber));
+    }
+}

--- a/src/test/java/com/example/gabojago_server/service/article/ArticleServiceTest.java
+++ b/src/test/java/com/example/gabojago_server/service/article/ArticleServiceTest.java
@@ -1,0 +1,126 @@
+package com.example.gabojago_server.service.article;
+
+import com.example.gabojago_server.config.JpaConfig;
+import com.example.gabojago_server.dto.response.article.ArticleResponseDto;
+import com.example.gabojago_server.model.member.Member;
+import com.example.gabojago_server.repository.article.article.ArticleRepository;
+import com.example.gabojago_server.repository.member.MemberRepository;
+import com.example.gabojago_server.steps.MemberStep;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({JpaConfig.class, ArticleService.class})
+class ArticleServiceTest {
+
+    @Autowired
+    private ArticleService articleService;
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private MemberStep memberStep;
+
+    @BeforeEach
+    void setup() {
+        memberStep = new MemberStep(memberRepository);
+    }
+
+    @Test
+    public void 커뮤니티_글_등록() throws Exception {
+        // given
+        Member writer = memberStep.createDefault();
+        String title = "[후기] 일본 갔다온 후기입니다.";
+        String content = "재미있었습니다.";
+
+        // when
+        ArticleResponseDto response = articleService.postArticle(writer.getId(), title, content);
+
+        // then
+        assertThat(response.getTitle()).isEqualTo(title);
+        assertThat(response.getContent()).isEqualTo(content);
+    }
+
+    @Test
+    public void 커뮤니티_글_수정() throws Exception {
+        // given
+        Member writer = memberStep.createDefault();
+        String title = "[후기] 일본 갔다온 후기입니다.";
+        String content = "재미있었습니다.";
+        ArticleResponseDto response = articleService.postArticle(writer.getId(), title, content);
+        String changeTitle = "[후기][재업로드] 일본 갔다온 후기입니다";
+        String changeContent = "[후기][재업로드] 너무 재미있었습니다.";
+
+        // when
+        ArticleResponseDto changeArticle =
+                articleService.changeArticle(writer.getId(), response.getArticleId(), changeTitle, changeContent);
+
+        // then
+        assertThat(changeArticle.getTitle()).isEqualTo(changeTitle);
+        assertThat(changeArticle.getContent()).isEqualTo(changeContent);
+    }
+
+
+    @Test
+    public void 커뮤니티_글_삭제() throws Exception {
+        // given
+        Member writer = memberStep.createDefault();
+        String title = "[후기] 일본 갔다온 후기입니다.";
+        String content = "재미있었습니다.";
+        ArticleResponseDto response = articleService.postArticle(writer.getId(), title, content);
+
+        // when
+        articleService.deleteArticle(writer.getId(), response.getArticleId());
+
+        // then
+        assertThat(articleRepository.findById(response.getArticleId()))
+                .isEmpty();
+    }
+
+    @Test
+    public void 커뮤니티_글_단일_조회() throws Exception {
+        // given
+        Member writer = memberStep.createDefault();
+        String title = "[후기] 일본 갔다온 후기입니다.";
+        String content = "재미있었습니다.";
+        ArticleResponseDto response = articleService.postArticle(writer.getId(), title, content);
+
+        // when
+        ArticleResponseDto articleResponseDto = articleService.oneArticle(writer.getId(), response.getArticleId());
+
+        // then
+        assertThat(articleResponseDto.getContent()).isEqualTo(content);
+        assertThat(articleResponseDto.getTitle()).isEqualTo(title);
+        assertThat(articleResponseDto.getNickname()).isEqualTo(writer.getNickname());
+    }
+
+    @Test
+    public void 커뮤니티_글_여러_조회() throws Exception {
+        // given
+        Member writer = memberStep.createDefault();
+        for (int i = 0; i < 200; i++) {
+            articleService.postArticle(writer.getId(),
+                    String.format("[%s] 번째 타이틀", i),
+                    String.format("[%s] 번째 내용", i));
+        }
+
+        // when
+        Page<ArticleResponseDto> response = articleService.allArticle(PageRequest.of(0, 10));
+
+        // then
+        assertThat(response.getContent().size()).isEqualTo(10);
+        assertThat(response.getTotalPages()).isEqualTo(20);
+    }
+
+
+}

--- a/src/test/java/com/example/gabojago_server/service/like/LikeServiceTest.java
+++ b/src/test/java/com/example/gabojago_server/service/like/LikeServiceTest.java
@@ -1,0 +1,104 @@
+package com.example.gabojago_server.service.like;
+
+import com.example.gabojago_server.config.JpaConfig;
+import com.example.gabojago_server.model.article.AccompanyArticle;
+import com.example.gabojago_server.model.article.Article;
+import com.example.gabojago_server.model.member.Member;
+import com.example.gabojago_server.repository.article.accompany.AccompanyArticleRepository;
+import com.example.gabojago_server.repository.article.article.ArticleRepository;
+import com.example.gabojago_server.repository.like.LikeRepository;
+import com.example.gabojago_server.repository.member.MemberRepository;
+import com.example.gabojago_server.steps.ArticleStep;
+import com.example.gabojago_server.steps.MemberStep;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({LikeService.class, JpaConfig.class})
+class LikeServiceTest {
+
+    @Autowired
+    private LikeService likeService;
+    @Autowired
+    private ArticleRepository articleRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private LikeRepository likeRepository;
+    @Autowired
+    private AccompanyArticleRepository accompanyArticleRepository;
+
+    private MemberStep memberStep;
+    private ArticleStep articleStep;
+
+
+    @BeforeEach
+    void setup() {
+        memberStep = new MemberStep(memberRepository);
+        articleStep = new ArticleStep(articleRepository);
+    }
+
+    @Test
+    public void 게시글에_좋아요_누르기() throws Exception {
+        // given
+        Member writer = memberStep.createDefault();
+        Article article = articleStep.createDefault(writer);
+
+        // when
+        likeService.clickLike(article.getId(), writer.getId());
+
+        // then
+        assertThat(likeRepository.findByArticleAndMember(article, writer))
+                .isPresent();
+    }
+
+    @Test
+    public void 게시글_좋아요_수_조회() throws Exception {
+        // given
+        Member writer = memberStep.createDefault();
+        Article article = articleStep.createDefault(writer);
+        likeService.clickLike(article.getId(), writer.getId());
+
+        // when
+        int likeNumber = likeService.getLike(article.getId());
+
+        // then
+
+        assertThat(likeNumber).isEqualTo(1);
+    }
+
+    @Test
+    public void 게시글_좋아요_수_조회_중복_좋아요_불가() throws Exception {
+        // given
+        Member writer = memberStep.createDefault();
+        Article article = articleStep.createDefault(writer);
+        likeService.clickLike(article.getId(), writer.getId());
+        likeService.clickLike(article.getId(), writer.getId());
+
+        // when
+        int likeNumber = likeService.getLike(article.getId());
+
+        // then
+
+        assertThat(likeNumber).isEqualTo(1);
+    }
+
+    @Test
+    public void 동행_게시글에_좋아요() throws Exception {
+        // given
+        Member writer = memberStep.createDefault();
+        AccompanyArticle article = articleStep.createAccompany(writer);
+        // when
+        likeService.clickLike(article.getId(), writer.getId());
+        // then
+
+        assertThat(likeRepository.findByArticleAndMember(article, writer))
+                .isPresent();
+    }
+
+}

--- a/src/test/java/com/example/gabojago_server/steps/ArticleStep.java
+++ b/src/test/java/com/example/gabojago_server/steps/ArticleStep.java
@@ -1,0 +1,37 @@
+package com.example.gabojago_server.steps;
+
+import com.example.gabojago_server.model.article.AccompanyArticle;
+import com.example.gabojago_server.model.article.Article;
+import com.example.gabojago_server.model.member.Member;
+import com.example.gabojago_server.repository.article.article.ArticleRepository;
+
+import static java.time.LocalDate.now;
+
+public class ArticleStep {
+    private final ArticleRepository articleRepository;
+
+    public ArticleStep(ArticleRepository articleRepository) {
+        this.articleRepository = articleRepository;
+    }
+
+    public Article createDefault(Member writer) {
+        return articleRepository.save(
+                Article.builder()
+                        .writer(writer)
+                        .title("제목")
+                        .content("제목")
+                        .build());
+    }
+
+    public AccompanyArticle createAccompany(Member writer) {
+        AccompanyArticle article = AccompanyArticle.createAccompanyArticle(
+                writer, "제목", "내용",
+                1, "서울", now(), now(),
+                2
+        );
+
+        return (AccompanyArticle) articleRepository.save(article);
+    }
+
+
+}

--- a/src/test/java/com/example/gabojago_server/steps/MemberStep.java
+++ b/src/test/java/com/example/gabojago_server/steps/MemberStep.java
@@ -1,0 +1,22 @@
+package com.example.gabojago_server.steps;
+
+import com.example.gabojago_server.model.member.Member;
+import com.example.gabojago_server.repository.member.MemberRepository;
+
+public class MemberStep {
+
+    public final MemberRepository memberRepository;
+
+    public MemberStep(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    public Member createDefault() {
+        return memberRepository.save(Member.builder()
+                .email("test@test.com")
+                .name("test")
+                .nickname("test")
+                .birth("1997-07-16")
+                .build());
+    }
+}


### PR DESCRIPTION
### 관련 이슈 번호
#14

### 변경 사항

- WebSecurityConfig 에서 /accompany/** -> /api/accompany/**  로 변경
- 추상 클래스 Article 를 Entity 로 승격하여 커뮤니티 게시글로서 역할을 변경 (기존 클래스 및 기능에 영향X)
- Controller 에서 findMemberId() 를 제거하고 SecurityUtil.getCurrentMemberIdx()를 staitc import 해서 사용
- 커뮤니티 CRUD 기능 구현 및 테스트
-  모든 게시글에 적용되는 좋아요 기능 구현 및 테스트
-  테스트 시 Member , Article 저장과 같은 반복 작업의 경우 Step 객체로 그 역할을 분리

### 리뷰 시 주의사항, 기타사항

- 모르고 메인 브랜치에 직접 merge 해버리는 이슈가 있었습니다 . 하지만 이를 되돌리는데 성공했습니다 (참고)