### PR TITLE
feat:[#21] 이메일 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
     //validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    //mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail:2.7.1'
+
     //QueryDsl
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
     implementation "com.querydsl:querydsl-apt:${queryDslVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     //mail
-    implementation 'org.springframework.boot:spring-boot-starter-mail:2.7.1'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     //QueryDsl
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
@@ -121,4 +121,8 @@ bootJar {
         from asciidoctor.outputDir
         into "src/main/resources/static/docs"
     }
+}
+
+compileJava {
+    options.compilerArgs += '-Xlint:unchecked'
 }

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -6,6 +6,19 @@
 :toclevels: 2
 :sectlinks:
 
+= 메일 검증
+
+include::{snippets}/member/auth/mailConfirm/http-request.adoc[]
+include::{snippets}/member/auth/mailConfirm/request-fields.adoc[]
+include::{snippets}/member/auth/mailConfirm/request-body.adoc[]
+
+=== 응답
+
+include::{snippets}/member/auth/mailConfirm/http-response.adoc[]
+include::{snippets}/member/auth/mailConfirm/response-fields.adoc[]
+include::{snippets}/member/auth/mailConfirm/response-body.adoc[]
+
+
 = 회원가입
 
 === 요청
@@ -60,6 +73,22 @@ include::{snippets}/member/info/password/request-body.adoc[]
 include::{snippets}/member/info/password/http-response.adoc[]
 include::{snippets}/member/info/password/response-fields.adoc[]
 include::{snippets}/member/info/password/response-body.adoc[]
+
+
+= 이메일로 회원 비밀번호 변경
+
+=== 요청
+
+include::{snippets}/member/auth/findPw/http-request.adoc[]
+include::{snippets}/member/auth/findPw/request-fields.adoc[]
+include::{snippets}/member/auth/findPw/request-body.adoc[]
+
+=== 응답
+
+include::{snippets}/member/auth/findPw/http-response.adoc[]
+include::{snippets}/member/auth/findPw/response-fields.adoc[]
+include::{snippets}/member/auth/findPw/response-body.adoc[]
+
 
 = 회원 전화번호 수정
 

--- a/src/main/java/com/example/gabojago_server/config/MailConfig.java
+++ b/src/main/java/com/example/gabojago_server/config/MailConfig.java
@@ -1,0 +1,52 @@
+package com.example.gabojago_server.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.ServletComponentScan;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+@PropertySource("classpath:application.yml")
+public class MailConfig {
+
+    @Value("${spring.mail.username}")
+    private String id;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Bean
+    public JavaMailSender javaMailService(){
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+
+        javaMailSender.setHost(host);
+        javaMailSender.setUsername(id);
+        javaMailSender.setPassword(password);
+        javaMailSender.setPort(port);
+        javaMailSender.setJavaMailProperties(getMailProperties());
+        javaMailSender.setDefaultEncoding("UTF-8");
+        return javaMailSender;
+    }
+
+    private Properties getMailProperties(){
+        Properties properties = new Properties();
+        properties.setProperty("mail.transport.protocol", "smtp");
+        properties.setProperty("mail.smtp.auth", "true");
+        properties.setProperty("mail.smtp.starttls.enable", "true");
+        properties.setProperty("mail.debug", "true");
+        properties.setProperty("mail.smtp.ssl.trust", "smtp.naver.com");
+        properties.setProperty("mail.smtp.ssl.enable", "true");
+        return properties;
+    }
+}

--- a/src/main/java/com/example/gabojago_server/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/gabojago_server/config/WebSecurityConfig.java
@@ -41,6 +41,7 @@ public class WebSecurityConfig {
                 .formLogin().disable()
                 .authorizeRequests()
                 .antMatchers("/auth/signup/**").permitAll()
+                .antMatchers("/auth/findPw/**").permitAll()
                 .antMatchers("/auth/login/**").permitAll()
                 .antMatchers("/login/**").permitAll()
                 .antMatchers("/oauth2/**").permitAll()

--- a/src/main/java/com/example/gabojago_server/dto/request/member/ChangeNickNameRequestDto.java
+++ b/src/main/java/com/example/gabojago_server/dto/request/member/ChangeNickNameRequestDto.java
@@ -12,10 +12,6 @@ import javax.validation.constraints.Pattern;
 @NoArgsConstructor
 public class ChangeNickNameRequestDto {
 
-    @NotBlank(message = "이메일을 입력하세요.")
-    @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식이 올바르지 않습니다.")
-    private String email;
-
     @NotBlank(message = "닉네임은 필수 입력 값입니다.")
     @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-z0-9-_]{2,10}$", message = "닉네임은 특수문자를 제외한 2~10자리여야 합니다.")
     private String nickname;

--- a/src/main/java/com/example/gabojago_server/dto/request/member/ChangePasswordRequestDto.java
+++ b/src/main/java/com/example/gabojago_server/dto/request/member/ChangePasswordRequestDto.java
@@ -16,10 +16,6 @@ public class ChangePasswordRequestDto {
     @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식이 올바르지 않습니다.")
     private String email;
 
-    @NotBlank(message = "비밀번호를 입력하세요.")
-    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자의 구성입니다.")
-    private String exPassword;
-
     @NotBlank(message = "새로운 비밀번호를 입력하세요.")
     @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자의 구성입니다.")
     private String newPassword;

--- a/src/main/java/com/example/gabojago_server/dto/request/member/ChangePasswordRequestDto.java
+++ b/src/main/java/com/example/gabojago_server/dto/request/member/ChangePasswordRequestDto.java
@@ -17,6 +17,6 @@ public class ChangePasswordRequestDto {
     private String email;
 
     @NotBlank(message = "새로운 비밀번호를 입력하세요.")
-    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자의 구성입니다.")
+    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[!@#$%^&*])(?=\\\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자의 구성입니다.")
     private String newPassword;
 }

--- a/src/main/java/com/example/gabojago_server/dto/request/member/ChangePasswordRequestDto.java
+++ b/src/main/java/com/example/gabojago_server/dto/request/member/ChangePasswordRequestDto.java
@@ -13,6 +13,6 @@ import javax.validation.constraints.Pattern;
 public class ChangePasswordRequestDto {
 
     @NotBlank(message = "새로운 비밀번호를 입력하세요.")
-    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[!@#$%^&*])(?=\\\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자의 구성입니다.")
+    @Pattern(regexp = "(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*])[A-Za-z\\d!@#$%^&*]{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자의 구성입니다.")
     private String newPassword;
 }

--- a/src/main/java/com/example/gabojago_server/dto/request/member/ChangePasswordRequestDto.java
+++ b/src/main/java/com/example/gabojago_server/dto/request/member/ChangePasswordRequestDto.java
@@ -12,10 +12,6 @@ import javax.validation.constraints.Pattern;
 @NoArgsConstructor
 public class ChangePasswordRequestDto {
 
-    @NotBlank(message = "이메일을 입력하세요.")
-    @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식이 올바르지 않습니다.")
-    private String email;
-
     @NotBlank(message = "새로운 비밀번호를 입력하세요.")
     @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[!@#$%^&*])(?=\\\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자의 구성입니다.")
     private String newPassword;

--- a/src/main/java/com/example/gabojago_server/dto/request/member/ChangePhoneRequestDto.java
+++ b/src/main/java/com/example/gabojago_server/dto/request/member/ChangePhoneRequestDto.java
@@ -12,10 +12,6 @@ import javax.validation.constraints.Pattern;
 @NoArgsConstructor
 public class ChangePhoneRequestDto {
 
-    @NotBlank(message = "이메일을 입력하세요.")
-    @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식이 올바르지 않습니다.")
-    private String email;
-
     @NotBlank(message = "핸드폰번호는 필수 입력 값입니다.")
     @Pattern(regexp = "^[0-9]{3}+-[0-9]{4}+-[0-9]{4}$", message = "번호 형식이 올바르지 않습니다.")
     private String phone;

--- a/src/main/java/com/example/gabojago_server/dto/request/member/EmailRequestDto.java
+++ b/src/main/java/com/example/gabojago_server/dto/request/member/EmailRequestDto.java
@@ -1,0 +1,19 @@
+package com.example.gabojago_server.dto.request.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EmailRequestDto {
+
+    @NotBlank(message = "이메일을 입력하세요.")
+    @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+
+}

--- a/src/main/java/com/example/gabojago_server/dto/request/member/LoginRequestDto.java
+++ b/src/main/java/com/example/gabojago_server/dto/request/member/LoginRequestDto.java
@@ -20,7 +20,7 @@ public class LoginRequestDto {
     private String email;
 
     @NotBlank(message = "비밀번호를 입력하세요.")
-    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[!@#$%^&*])(?=\\\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자의 구성입니다.")
+    @Pattern(regexp = "(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*])[A-Za-z\\d!@#$%^&*]{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자의 구성입니다.")
     private String password;
 
     public UsernamePasswordAuthenticationToken toAuthentication() {

--- a/src/main/java/com/example/gabojago_server/dto/request/member/LoginRequestDto.java
+++ b/src/main/java/com/example/gabojago_server/dto/request/member/LoginRequestDto.java
@@ -20,7 +20,7 @@ public class LoginRequestDto {
     private String email;
 
     @NotBlank(message = "비밀번호를 입력하세요.")
-    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자의 구성입니다.")
+    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[!@#$%^&*])(?=\\\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자의 구성입니다.")
     private String password;
 
     public UsernamePasswordAuthenticationToken toAuthentication() {

--- a/src/main/java/com/example/gabojago_server/dto/request/member/MailConfirmRequest.java
+++ b/src/main/java/com/example/gabojago_server/dto/request/member/MailConfirmRequest.java
@@ -1,0 +1,12 @@
+package com.example.gabojago_server.dto.request.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MailConfirmRequest {
+    private String email;
+}

--- a/src/main/java/com/example/gabojago_server/dto/request/member/MemberRequestDto.java
+++ b/src/main/java/com/example/gabojago_server/dto/request/member/MemberRequestDto.java
@@ -23,7 +23,7 @@ public class MemberRequestDto {
     private String email;
 
     @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
-    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
+    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[!@#$%^&*])(?=\\\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
     private String password;
 
     @NotBlank(message = "이름은 필수 입력 값입니다.")

--- a/src/main/java/com/example/gabojago_server/dto/request/member/MemberRequestDto.java
+++ b/src/main/java/com/example/gabojago_server/dto/request/member/MemberRequestDto.java
@@ -23,7 +23,7 @@ public class MemberRequestDto {
     private String email;
 
     @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
-    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[!@#$%^&*])(?=\\\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
+    @Pattern(regexp = "(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*])[A-Za-z\\d!@#$%^&*]{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
     private String password;
 
     @NotBlank(message = "이름은 필수 입력 값입니다.")

--- a/src/main/java/com/example/gabojago_server/dto/response/NormalResponse.java
+++ b/src/main/java/com/example/gabojago_server/dto/response/NormalResponse.java
@@ -20,4 +20,8 @@ public class NormalResponse {
     public static NormalResponse fail(){
         return new NormalResponse("FAIL");
     }
+
+    public static NormalResponse duplicated(){
+        return new NormalResponse("DUPLICATED DATA");
+    }
 }

--- a/src/main/java/com/example/gabojago_server/dto/response/member/EmailConfirmResponse.java
+++ b/src/main/java/com/example/gabojago_server/dto/response/member/EmailConfirmResponse.java
@@ -1,0 +1,12 @@
+package com.example.gabojago_server.dto.response.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EmailConfirmResponse {
+    private String data;
+}

--- a/src/main/java/com/example/gabojago_server/service/mail/ChangePwEmailService.java
+++ b/src/main/java/com/example/gabojago_server/service/mail/ChangePwEmailService.java
@@ -3,7 +3,7 @@ package com.example.gabojago_server.service.mail;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.PropertySource;
+
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -14,15 +14,14 @@ import javax.mail.internet.MimeMessage;
 import java.io.UnsupportedEncodingException;
 import java.util.Random;
 
-@PropertySource("classpath:application.yml")
 @Slf4j
-@RequiredArgsConstructor
 @Service
+@RequiredArgsConstructor
 public class ChangePwEmailService {
 
-    private final JavaMailSender javaMailSender;
+    private final JavaMailSender emailsender;
 
-    private final String ePw = createKey(); //인증번호
+    private String ePw = createKey(); //인증번호
 
     @Value("${spring.mail.username}")
     private String id;
@@ -33,7 +32,7 @@ public class ChangePwEmailService {
         log.info("보내는 대상 : " + to);
         log.info("인증 번호 : " + ePw);
 
-        MimeMessage message = javaMailSender.createMimeMessage();
+        MimeMessage message = emailsender.createMimeMessage();
 
         message.addRecipients(MimeMessage.RecipientType.TO, to);    //수신자
         message.setSubject("가보자Go 임시 비밀번호입니다.");   //메일 제목
@@ -103,7 +102,7 @@ public class ChangePwEmailService {
         MimeMessage message = createMessage(to);
 
         try{
-            javaMailSender.send(message);
+            emailsender.send(message);
         }catch (MailException es){
             es.printStackTrace();
             throw new IllegalAccessException();

--- a/src/main/java/com/example/gabojago_server/service/mail/ChangePwEmailService.java
+++ b/src/main/java/com/example/gabojago_server/service/mail/ChangePwEmailService.java
@@ -1,9 +1,9 @@
 package com.example.gabojago_server.service.mail;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -17,16 +17,50 @@ import java.util.Random;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Getter
 public class ChangePwEmailService {
 
+    private static final String SPECIAL_CHARS = "!@#$%^&*";
     private final JavaMailSender emailsender;
-
     private String ePw = createKey(); //인증번호
-
     @Value("${spring.mail.username}")
     private String id;
 
-    private static final String SPECIAL_CHARS = "!@#$%^&*";
+    //인증 코드 만들기
+    public static String createKey() {
+        StringBuffer key = new StringBuffer();
+        Random random = new Random();
+
+        key.append((char) ((int) random.nextInt(26) + 97));
+        key.append((char) ((int) random.nextInt(26) + 65));
+        key.append(random.nextInt(10));
+
+        int charIdx = random.nextInt(SPECIAL_CHARS.length());
+        char specialChar = SPECIAL_CHARS.charAt(charIdx);
+        key.append(specialChar);
+
+        while (key.length() < 8) {
+            int idx = random.nextInt(4);
+
+            switch (idx) {
+                case 0:
+                    key.append((char) ((int) random.nextInt(26) + 97));
+                    break;
+                case 1:
+                    key.append((char) ((int) random.nextInt(26) + 65));
+                    break;
+                case 2:
+                    key.append(random.nextInt(10));
+                    break;
+                case 3:
+                    charIdx = random.nextInt(SPECIAL_CHARS.length());
+                    specialChar = SPECIAL_CHARS.charAt(charIdx);
+                    key.append(specialChar);
+                    break;
+            }
+        }
+        return key.toString();
+    }
 
     public MimeMessage createMessage(String to) throws MessagingException, UnsupportedEncodingException {
         log.info("보내는 대상 : " + to);
@@ -39,7 +73,7 @@ public class ChangePwEmailService {
 
         String msg = "";
         msg += "<div style='margin:100px;'>";
-        msg += "<h1 style=\"font-size: 30px; padding-right: 30px; padding-left: 30px;\">가보자Go 비밀번호 재설정을 위한 임시 비밃번호입니다.</h1>";
+        msg += "<h1 style=\"font-size: 30px; padding-right: 30px; padding-left: 30px;\">가보자Go 비밀번호 재설정을 위한 임시 비밀번호입니다.</h1>";
         msg += "<p style=\"font-size: 17px; padding-right: 30px; padding-left: 30px;\">아래 임시 비밀번호로 로그인 후 새로운 비밀번호로 변경 부탁드립니다.</p>";
         msg += "<div style=\"padding-right: 30px; padding-left: 30px; margin: 32px 0 40px;\"><table style=\"border-collapse: collapse; border: 0; background-color: #F4F4F4; height: 70px; table-layout: fixed; word-wrap: break-word; border-radius: 6px;\"><tbody><tr><td style=\"text-align: center; vertical-align: middle; font-size: 30px;\">";
         msg += ePw;
@@ -51,59 +85,13 @@ public class ChangePwEmailService {
         return message;
     }
 
-
-    //인증 코드 만들기
-    public static String createKey(){
-        StringBuffer key = new StringBuffer();
-        Random random = new Random();
-
-        boolean hasUpperCase = false;
-        boolean hasLowerCase = false;
-        boolean hasNumber = false;
-        boolean hasSpecialChar = false;
-
-        while(key.length()<8 || !(hasLowerCase && hasUpperCase && hasNumber && hasSpecialChar)){
-            int idx = random.nextInt(4);
-
-            switch (idx){
-                case 0:
-                    if(!hasLowerCase) {
-                        key.append((char) ((int) random.nextInt(26) + 97));
-                        hasLowerCase = true;
-                    }
-                    break;
-                case 1:
-                    if(!hasUpperCase) {
-                        key.append((char) ((int) random.nextInt(26) + 65));
-                        hasUpperCase = true;
-                    }
-                    break;
-                case 2:
-                    if(!hasNumber) {
-                        key.append(random.nextInt(10));
-                        hasNumber = true;
-                    }
-                    break;
-                case 3:
-                    if(!hasSpecialChar) {
-                        int charIdx = random.nextInt(SPECIAL_CHARS.length());
-                        char specialChar = SPECIAL_CHARS.charAt(charIdx);
-                        key.append(specialChar);
-                        hasSpecialChar = true;
-                    }
-                    break;
-            }
-        }
-        return key.toString();
-    }
-
     //메일 발송
     public String sendSimpleMessage(String to) throws Exception {
         MimeMessage message = createMessage(to);
 
-        try{
+        try {
             emailsender.send(message);
-        }catch (MailException es){
+        } catch (MailException es) {
             es.printStackTrace();
             throw new IllegalAccessException();
         }

--- a/src/main/java/com/example/gabojago_server/service/mail/ChangePwEmailService.java
+++ b/src/main/java/com/example/gabojago_server/service/mail/ChangePwEmailService.java
@@ -58,23 +58,40 @@ public class ChangePwEmailService {
         StringBuffer key = new StringBuffer();
         Random random = new Random();
 
-        for(int i = 0; i<8; i++){
+        boolean hasUpperCase = false;
+        boolean hasLowerCase = false;
+        boolean hasNumber = false;
+        boolean hasSpecialChar = false;
+
+        while(key.length()<8 || !(hasLowerCase && hasUpperCase && hasNumber && hasSpecialChar)){
             int idx = random.nextInt(4);
 
             switch (idx){
                 case 0:
-                    key.append((char) ((int) random.nextInt(26) + 97));
+                    if(!hasLowerCase) {
+                        key.append((char) ((int) random.nextInt(26) + 97));
+                        hasLowerCase = true;
+                    }
                     break;
                 case 1:
-                    key.append((char) ((int) random.nextInt(26) + 65));
+                    if(!hasUpperCase) {
+                        key.append((char) ((int) random.nextInt(26) + 65));
+                        hasUpperCase = true;
+                    }
                     break;
                 case 2:
-                    key.append(random.nextInt(10));
+                    if(!hasNumber) {
+                        key.append(random.nextInt(10));
+                        hasNumber = true;
+                    }
                     break;
                 case 3:
-                    int charIdx = random.nextInt(SPECIAL_CHARS.length());
-                    char specialChar = SPECIAL_CHARS.charAt(charIdx);
-                    key.append(specialChar);
+                    if(!hasSpecialChar) {
+                        int charIdx = random.nextInt(SPECIAL_CHARS.length());
+                        char specialChar = SPECIAL_CHARS.charAt(charIdx);
+                        key.append(specialChar);
+                        hasSpecialChar = true;
+                    }
                     break;
             }
         }

--- a/src/main/java/com/example/gabojago_server/service/mail/ChangePwEmailService.java
+++ b/src/main/java/com/example/gabojago_server/service/mail/ChangePwEmailService.java
@@ -1,0 +1,97 @@
+package com.example.gabojago_server.service.mail;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import java.io.UnsupportedEncodingException;
+import java.util.Random;
+
+@PropertySource("classpath:application.yml")
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ChangePwEmailService {
+
+    private final JavaMailSender javaMailSender;
+
+    private final String ePw = createKey(); //인증번호
+
+    @Value("${spring.mail.username}")
+    private String id;
+
+    private static final String SPECIAL_CHARS = "!@#$%^&*";
+
+    public MimeMessage createMessage(String to) throws MessagingException, UnsupportedEncodingException {
+        log.info("보내는 대상 : " + to);
+        log.info("인증 번호 : " + ePw);
+
+        MimeMessage message = javaMailSender.createMimeMessage();
+
+        message.addRecipients(MimeMessage.RecipientType.TO, to);    //수신자
+        message.setSubject("가보자Go 임시 비밀번호입니다.");   //메일 제목
+
+        String msg = "";
+        msg += "<div style='margin:100px;'>";
+        msg += "<h1 style=\"font-size: 30px; padding-right: 30px; padding-left: 30px;\">가보자Go 비밀번호 재설정을 위한 임시 비밃번호입니다.</h1>";
+        msg += "<p style=\"font-size: 17px; padding-right: 30px; padding-left: 30px;\">아래 임시 비밀번호로 로그인 후 새로운 비밀번호로 변경 부탁드립니다.</p>";
+        msg += "<div style=\"padding-right: 30px; padding-left: 30px; margin: 32px 0 40px;\"><table style=\"border-collapse: collapse; border: 0; background-color: #F4F4F4; height: 70px; table-layout: fixed; word-wrap: break-word; border-radius: 6px;\"><tbody><tr><td style=\"text-align: center; vertical-align: middle; font-size: 30px;\">";
+        msg += ePw;
+        msg += "</td></tr></tbody></table></div>";
+
+        message.setText(msg, "utf-8", "html");
+        message.setFrom(new InternetAddress(id, "gabojago_Admin"));
+
+        return message;
+    }
+
+
+    //인증 코드 만들기
+    public static String createKey(){
+        StringBuffer key = new StringBuffer();
+        Random random = new Random();
+
+        for(int i = 0; i<8; i++){
+            int idx = random.nextInt(4);
+
+            switch (idx){
+                case 0:
+                    key.append((char) ((int) random.nextInt(26) + 97));
+                    break;
+                case 1:
+                    key.append((char) ((int) random.nextInt(26) + 65));
+                    break;
+                case 2:
+                    key.append(random.nextInt(10));
+                    break;
+                case 3:
+                    int charIdx = random.nextInt(SPECIAL_CHARS.length());
+                    char specialChar = SPECIAL_CHARS.charAt(charIdx);
+                    key.append(specialChar);
+                    break;
+            }
+        }
+        return key.toString();
+    }
+
+    //메일 발송
+    public String sendSimpleMessage(String to) throws Exception {
+        MimeMessage message = createMessage(to);
+
+        try{
+            javaMailSender.send(message);
+        }catch (MailException es){
+            es.printStackTrace();
+            throw new IllegalAccessException();
+        }
+        return ePw;
+    }
+
+}

--- a/src/main/java/com/example/gabojago_server/service/mail/SignupEmailService.java
+++ b/src/main/java/com/example/gabojago_server/service/mail/SignupEmailService.java
@@ -1,9 +1,9 @@
 package com.example.gabojago_server.service.mail;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.PropertySource;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -14,24 +14,48 @@ import javax.mail.internet.MimeMessage;
 import java.io.UnsupportedEncodingException;
 import java.util.Random;
 
-@PropertySource("classpath:application.yml")
+
 @Slf4j
-@RequiredArgsConstructor
 @Service
+@RequiredArgsConstructor
+@Getter
 public class SignupEmailService {
 
-    private final JavaMailSender javaMailSender;
+    private final JavaMailSender emailsender;
 
     private final String ePw = createKey(); //인증번호
 
     @Value("${spring.mail.username}")
     private String id;
 
+    //인증 코드 만들기
+    public static String createKey() {
+        StringBuffer key = new StringBuffer();
+        Random random = new Random();
+
+        for (int i = 0; i < 8; i++) {
+            int idx = random.nextInt(3);
+
+            switch (idx) {
+                case 0:
+                    key.append((char) ((int) random.nextInt(26) + 97));
+                    break;
+                case 1:
+                    key.append((char) ((int) random.nextInt(26) + 65));
+                    break;
+                case 2:
+                    key.append(random.nextInt(10));
+                    break;
+            }
+        }
+        return key.toString();
+    }
+
     public MimeMessage createMessage(String to) throws MessagingException, UnsupportedEncodingException {
         log.info("보내는 대상 : " + to);
         log.info("인증 번호 : " + ePw);
 
-        MimeMessage message = javaMailSender.createMimeMessage();
+        MimeMessage message = emailsender.createMimeMessage();
 
         message.addRecipients(MimeMessage.RecipientType.TO, to);    //수신자
         message.setSubject("가보자Go 이메일 인증 코드입니다.");   //메일 제목
@@ -50,37 +74,13 @@ public class SignupEmailService {
         return message;
     }
 
-
-    //인증 코드 만들기
-    public static String createKey(){
-        StringBuffer key = new StringBuffer();
-        Random random = new Random();
-
-        for(int i = 0; i<8; i++){
-            int idx = random.nextInt(3);
-
-            switch (idx){
-                case 0:
-                    key.append((char) ((int) random.nextInt(26) + 97));
-                    break;
-                case 1:
-                    key.append((char) ((int) random.nextInt(26) + 65));
-                    break;
-                case 2:
-                    key.append(random.nextInt(10));
-                    break;
-            }
-        }
-        return key.toString();
-    }
-
     //메일 발송
     public String sendSimpleMessage(String to) throws Exception {
         MimeMessage message = createMessage(to);
 
-        try{
-            javaMailSender.send(message);
-        }catch (MailException es){
+        try {
+            emailsender.send(message);
+        } catch (MailException es) {
             es.printStackTrace();
             throw new IllegalAccessException();
         }

--- a/src/main/java/com/example/gabojago_server/service/mail/SignupEmailService.java
+++ b/src/main/java/com/example/gabojago_server/service/mail/SignupEmailService.java
@@ -1,0 +1,89 @@
+package com.example.gabojago_server.service.mail;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import java.io.UnsupportedEncodingException;
+import java.util.Random;
+
+@PropertySource("classpath:application.yml")
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class SignupEmailService {
+
+    private final JavaMailSender javaMailSender;
+
+    private final String ePw = createKey(); //인증번호
+
+    @Value("${spring.mail.username}")
+    private String id;
+
+    public MimeMessage createMessage(String to) throws MessagingException, UnsupportedEncodingException {
+        log.info("보내는 대상 : " + to);
+        log.info("인증 번호 : " + ePw);
+
+        MimeMessage message = javaMailSender.createMimeMessage();
+
+        message.addRecipients(MimeMessage.RecipientType.TO, to);    //수신자
+        message.setSubject("가보자Go 이메일 인증 코드입니다.");   //메일 제목
+
+        String msg = "";
+        msg += "<div style='margin:100px;'>";
+        msg += "<h1 style=\"font-size: 30px; padding-right: 30px; padding-left: 30px;\">가보자Go 이메일 인증 확인</h1>";
+        msg += "<p style=\"font-size: 17px; padding-right: 30px; padding-left: 30px;\">아래 확인 코드를 회원가입 화면으로 돌아가 입력해주세요.</p>";
+        msg += "<div style=\"padding-right: 30px; padding-left: 30px; margin: 32px 0 40px;\"><table style=\"border-collapse: collapse; border: 0; background-color: #F4F4F4; height: 70px; table-layout: fixed; word-wrap: break-word; border-radius: 6px;\"><tbody><tr><td style=\"text-align: center; vertical-align: middle; font-size: 30px;\">";
+        msg += ePw;
+        msg += "</td></tr></tbody></table></div>";
+
+        message.setText(msg, "utf-8", "html");
+        message.setFrom(new InternetAddress(id, "gabojago_Admin"));
+
+        return message;
+    }
+
+
+    //인증 코드 만들기
+    public static String createKey(){
+        StringBuffer key = new StringBuffer();
+        Random random = new Random();
+
+        for(int i = 0; i<8; i++){
+            int idx = random.nextInt(3);
+
+            switch (idx){
+                case 0:
+                    key.append((char) ((int) random.nextInt(26) + 97));
+                    break;
+                case 1:
+                    key.append((char) ((int) random.nextInt(26) + 65));
+                    break;
+                case 2:
+                    key.append(random.nextInt(10));
+                    break;
+            }
+        }
+        return key.toString();
+    }
+
+    //메일 발송
+    public String sendSimpleMessage(String to) throws Exception {
+        MimeMessage message = createMessage(to);
+
+        try{
+            javaMailSender.send(message);
+        }catch (MailException es){
+            es.printStackTrace();
+            throw new IllegalAccessException();
+        }
+        return ePw;
+    }
+}

--- a/src/main/java/com/example/gabojago_server/service/member/AuthService.java
+++ b/src/main/java/com/example/gabojago_server/service/member/AuthService.java
@@ -15,6 +15,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -46,6 +48,11 @@ public class AuthService {
 
     public boolean findMember(String email){
         return memberRepository.existsByEmail(email);
+    }
+
+    public void changeTempPw(String email, String newPassword){
+        Member member = memberRepository.findByEmail(email).orElseThrow(() -> new RuntimeException("가입되지 않은 이메일입니다"));
+        member.updatePassword(passwordEncoder.encode((newPassword)));
     }
 
 }

--- a/src/main/java/com/example/gabojago_server/service/member/AuthService.java
+++ b/src/main/java/com/example/gabojago_server/service/member/AuthService.java
@@ -44,4 +44,8 @@ public class AuthService {
         return jwtTokenProvider.createToken(authentication);
     }
 
+    public boolean findMember(String email){
+        return memberRepository.existsByEmail(email);
+    }
+
 }

--- a/src/main/java/com/example/gabojago_server/service/member/MemberService.java
+++ b/src/main/java/com/example/gabojago_server/service/member/MemberService.java
@@ -33,11 +33,8 @@ public class MemberService {
     }
 
     @Transactional
-    public MemberResponseDto changePassword(String email, String exPassword, String newPassword) {
+    public MemberResponseDto changePassword(String email,  String newPassword) {
         Member member = memberRepository.findByEmail(email).orElseThrow(() -> new RuntimeException("로그인 유저 정보가 없습니다"));
-        if (!passwordEncoder.matches(exPassword, member.getPassword())) {
-            throw new RuntimeException("비밀번호가 맞지 않습니다");
-        }
         member.updatePassword(passwordEncoder.encode((newPassword)));
         return MemberResponseDto.of(memberRepository.save(member));
     }

--- a/src/main/java/com/example/gabojago_server/service/member/MemberService.java
+++ b/src/main/java/com/example/gabojago_server/service/member/MemberService.java
@@ -26,22 +26,22 @@ public class MemberService {
     }
 
     @Transactional
-    public MemberResponseDto changeNickname(String email, String nickname) {
-        Member member = memberRepository.findByEmail(email).orElseThrow(() -> new RuntimeException("로그인 유저 정보가 없습니다"));
+    public MemberResponseDto changeNickname(Long id, String nickname) {
+        Member member = memberRepository.findById(id).orElseThrow(() -> new RuntimeException("로그인 유저 정보가 없습니다"));
         member.updateNickName((nickname));
         return MemberResponseDto.of(memberRepository.save(member));
     }
 
     @Transactional
-    public MemberResponseDto changePassword(String email,  String newPassword) {
-        Member member = memberRepository.findByEmail(email).orElseThrow(() -> new RuntimeException("로그인 유저 정보가 없습니다"));
+    public MemberResponseDto changePassword(Long id,  String newPassword) {
+        Member member = memberRepository.findById(id).orElseThrow(() -> new RuntimeException("로그인 유저 정보가 없습니다"));
         member.updatePassword(passwordEncoder.encode((newPassword)));
         return MemberResponseDto.of(memberRepository.save(member));
     }
 
     @Transactional
-    public MemberResponseDto changePhone(String email, String phone) {
-        Member member = memberRepository.findByEmail(email).orElseThrow(() -> new RuntimeException("로그인 유저 정보가 없습니다"));
+    public MemberResponseDto changePhone(Long id, String phone) {
+        Member member = memberRepository.findById(id).orElseThrow(() -> new RuntimeException("로그인 유저 정보가 없습니다"));
         member.updatePhone((phone));
         return MemberResponseDto.of(memberRepository.save(member));
     }

--- a/src/main/java/com/example/gabojago_server/web/controller/member/AuthController.java
+++ b/src/main/java/com/example/gabojago_server/web/controller/member/AuthController.java
@@ -5,6 +5,7 @@ import com.example.gabojago_server.dto.request.member.EmailRequestDto;
 import com.example.gabojago_server.dto.request.member.LoginRequestDto;
 import com.example.gabojago_server.dto.request.member.MemberRequestDto;
 import com.example.gabojago_server.dto.response.NormalResponse;
+import com.example.gabojago_server.dto.response.member.EmailConfirmResponse;
 import com.example.gabojago_server.dto.response.member.MemberResponseDto;
 import com.example.gabojago_server.service.mail.ChangePwEmailService;
 import com.example.gabojago_server.service.mail.SignupEmailService;
@@ -33,11 +34,11 @@ public class AuthController {
 
     @PostMapping("/signup/mailConfirm")
     @ResponseBody
-    public ResponseEntity<String> mailConfirm(@RequestBody EmailRequestDto requestDto) throws Exception {
+    public ResponseEntity<EmailConfirmResponse> mailConfirm(@RequestBody EmailRequestDto requestDto) throws Exception {
         if (authService.findMember(requestDto.getEmail()))
-            return ResponseEntity.ok(NormalResponse.duplicated().getStatus());
+            return ResponseEntity.ok(null); // TODO : 예외 처리
         String code = signupEmailService.sendSimpleMessage(requestDto.getEmail());
-        return ResponseEntity.ok(code);
+        return ResponseEntity.ok(new EmailConfirmResponse(code));
     }
 
     @PostMapping("/login")

--- a/src/main/java/com/example/gabojago_server/web/controller/member/AuthController.java
+++ b/src/main/java/com/example/gabojago_server/web/controller/member/AuthController.java
@@ -1,6 +1,7 @@
 package com.example.gabojago_server.web.controller.member;
 
 import com.example.gabojago_server.dto.TokenDto;
+import com.example.gabojago_server.dto.request.member.EmailRequestDto;
 import com.example.gabojago_server.dto.request.member.LoginRequestDto;
 import com.example.gabojago_server.dto.request.member.MemberRequestDto;
 import com.example.gabojago_server.dto.response.NormalResponse;
@@ -32,9 +33,10 @@ public class AuthController {
 
     @PostMapping("/signup/mailConfirm")
     @ResponseBody
-    public ResponseEntity<String> mailConfirm(@RequestBody String email) throws Exception {
-        if (authService.findMember(email)) return ResponseEntity.ok(NormalResponse.duplicated().getStatus());
-        String code = signupEmailService.sendSimpleMessage(email);
+    public ResponseEntity<String> mailConfirm(@RequestBody EmailRequestDto requestDto) throws Exception {
+        if (authService.findMember(requestDto.getEmail()))
+            return ResponseEntity.ok(NormalResponse.duplicated().getStatus());
+        String code = signupEmailService.sendSimpleMessage(requestDto.getEmail());
         return ResponseEntity.ok(code);
     }
 
@@ -45,10 +47,10 @@ public class AuthController {
 
     @PostMapping("/findPw")
     @ResponseBody
-    public ResponseEntity<NormalResponse> findPw(@RequestBody String email) throws Exception {
-        if (authService.findMember(email)) {
-            String newPassword = pwEmailService.sendSimpleMessage(email);
-            authService.changeTempPw(email, newPassword);
+    public ResponseEntity<NormalResponse> findPw(@RequestBody EmailRequestDto requestDto) throws Exception {
+        if (authService.findMember(requestDto.getEmail())) {
+            String newPassword = pwEmailService.sendSimpleMessage(requestDto.getEmail());
+            authService.changeTempPw(requestDto.getEmail(), newPassword);
             return ResponseEntity.ok(NormalResponse.success());
         } else {
             return ResponseEntity.ok(NormalResponse.fail());

--- a/src/main/java/com/example/gabojago_server/web/controller/member/AuthController.java
+++ b/src/main/java/com/example/gabojago_server/web/controller/member/AuthController.java
@@ -35,9 +35,10 @@ public class AuthController {
 
     @PostMapping("/signup/mailConfirm")
     @ResponseBody
-    String mailConfirm(@RequestParam("email") String email) throws Exception {
+    public ResponseEntity<String> mailConfirm(@RequestParam("email") String email) throws Exception {
+        if(authService.findMember(email)) return ResponseEntity.ok(NormalResponse.fail().getStatus());
         String code = signupEmailService.sendSimpleMessage(email);
-        return code;
+        return ResponseEntity.ok(code);
     }
 
     @PostMapping("/login")

--- a/src/main/java/com/example/gabojago_server/web/controller/member/AuthController.java
+++ b/src/main/java/com/example/gabojago_server/web/controller/member/AuthController.java
@@ -4,7 +4,10 @@ import com.example.gabojago_server.dto.TokenDto;
 import com.example.gabojago_server.dto.request.member.LoginRequestDto;
 import com.example.gabojago_server.dto.request.member.MemberRequestDto;
 import com.example.gabojago_server.dto.response.member.MemberResponseDto;
+import com.example.gabojago_server.service.mail.ChangePwEmailService;
+import com.example.gabojago_server.service.mail.SignupEmailService;
 import com.example.gabojago_server.service.member.AuthService;
+import com.example.gabojago_server.service.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,9 +21,20 @@ public class AuthController {
 
     private final AuthService authService;
 
+    private final SignupEmailService signupEmailService;
+
+    private final ChangePwEmailService pwEmailService;
+
     @PostMapping("/signup")
     public ResponseEntity<MemberResponseDto> signup(@RequestBody @Valid MemberRequestDto requestDto) {
         return ResponseEntity.ok(authService.joinMember(requestDto));
+    }
+
+    @PostMapping("/signup/mailConfirm")
+    @ResponseBody
+    String mailConfirm(@RequestParam("email") String email) throws Exception {
+        String code = signupEmailService.sendSimpleMessage(email);
+        return code;
     }
 
     @PostMapping("/login")

--- a/src/main/java/com/example/gabojago_server/web/controller/member/AuthController.java
+++ b/src/main/java/com/example/gabojago_server/web/controller/member/AuthController.java
@@ -3,6 +3,7 @@ package com.example.gabojago_server.web.controller.member;
 import com.example.gabojago_server.dto.TokenDto;
 import com.example.gabojago_server.dto.request.member.LoginRequestDto;
 import com.example.gabojago_server.dto.request.member.MemberRequestDto;
+import com.example.gabojago_server.dto.response.NormalResponse;
 import com.example.gabojago_server.dto.response.member.MemberResponseDto;
 import com.example.gabojago_server.service.mail.ChangePwEmailService;
 import com.example.gabojago_server.service.mail.SignupEmailService;
@@ -20,6 +21,8 @@ import javax.validation.Valid;
 public class AuthController {
 
     private final AuthService authService;
+
+    private final MemberService memberService;
 
     private final SignupEmailService signupEmailService;
 
@@ -40,6 +43,17 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<TokenDto> login(@RequestBody LoginRequestDto loginRequestDto) {
         return ResponseEntity.ok(authService.loginMember(loginRequestDto));
+    }
+
+    @PostMapping("/login/findPw")
+    @ResponseBody
+    public ResponseEntity<NormalResponse> findPw(@RequestParam("email") String email) throws Exception {
+        if(authService.findMember(email)){
+            String tempPw = pwEmailService.sendSimpleMessage(email);
+            memberService.changePassword(email, tempPw);
+            return ResponseEntity.ok(NormalResponse.success());
+        }
+        return ResponseEntity.ok(NormalResponse.fail());
     }
 
     @GetMapping("/token")

--- a/src/main/java/com/example/gabojago_server/web/controller/member/MemberController.java
+++ b/src/main/java/com/example/gabojago_server/web/controller/member/MemberController.java
@@ -41,7 +41,7 @@ public class MemberController {
 
     @PostMapping("/password")
     public ResponseEntity<MemberResponseDto> setMemberPassword(@RequestBody @Valid ChangePasswordRequestDto request) {
-        return ResponseEntity.ok(memberService.changePassword(request.getEmail(), request.getExPassword(), request.getNewPassword()));
+        return ResponseEntity.ok(memberService.changePassword(request.getEmail(),  request.getNewPassword()));
     }
 
     @PostMapping("/phone")

--- a/src/main/java/com/example/gabojago_server/web/controller/member/MemberController.java
+++ b/src/main/java/com/example/gabojago_server/web/controller/member/MemberController.java
@@ -36,17 +36,17 @@ public class MemberController {
 
     @PostMapping("/nickname")
     public ResponseEntity<MemberResponseDto> setMemberNickname(@RequestBody @Valid ChangeNickNameRequestDto request) {
-        return ResponseEntity.ok(memberService.changeNickname(request.getEmail(), request.getNickname()));
+        return ResponseEntity.ok(memberService.changeNickname(getCurrentMemberIdx(), request.getNickname()));
     }
 
     @PostMapping("/password")
     public ResponseEntity<MemberResponseDto> setMemberPassword(@RequestBody @Valid ChangePasswordRequestDto request) {
-        return ResponseEntity.ok(memberService.changePassword(request.getEmail(),  request.getNewPassword()));
+        return ResponseEntity.ok(memberService.changePassword(getCurrentMemberIdx(),  request.getNewPassword()));
     }
 
     @PostMapping("/phone")
     public ResponseEntity<MemberResponseDto> setMemberPhone(@RequestBody @Valid ChangePhoneRequestDto request) {
-        return ResponseEntity.ok(memberService.changePhone(request.getEmail(), request.getPhone()));
+        return ResponseEntity.ok(memberService.changePhone(getCurrentMemberIdx(), request.getPhone()));
     }
 
     @GetMapping("/alarms")

--- a/src/main/resources/static/docs/accompany.html
+++ b/src/main/resources/static/docs/accompany.html
@@ -541,8 +541,8 @@ Content-Length: 714
   "pageable" : {
     "sort" : {
       "empty" : true,
-      "sorted" : false,
-      "unsorted" : true
+      "unsorted" : true,
+      "sorted" : false
     },
     "offset" : 0,
     "pageNumber" : 0,
@@ -550,15 +550,15 @@ Content-Length: 714
     "paged" : true,
     "unpaged" : false
   },
-  "totalElements" : 1,
   "totalPages" : 1,
+  "totalElements" : 1,
   "last" : true,
   "size" : 10,
   "number" : 0,
   "sort" : {
     "empty" : true,
-    "sorted" : false,
-    "unsorted" : true
+    "unsorted" : true,
+    "sorted" : false
   },
   "numberOfElements" : 1,
   "first" : true,
@@ -676,6 +676,11 @@ Content-Length: 714
 <td class="tableblock halign-left valign-top"><p class="tableblock">페이지 여부</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">동행글 제목</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].region</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">동행 지역</p></td>
@@ -714,11 +719,6 @@ Content-Length: 714
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].nickname</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">작성자 닉네임</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].title</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">동행글 제목</p></td>
 </tr>
 </tbody>
 </table>
@@ -795,6 +795,16 @@ Content-Length: 240
 </thead>
 <tbody>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>region</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">동행 지역</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>written</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자인지 여부</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>review</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">동행글 조회수</p></td>
@@ -833,16 +843,6 @@ Content-Length: 240
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">작성자 닉네임</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>region</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">동행 지역</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>written</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">작성자인지 여부</p></td>
 </tr>
 </tbody>
 </table>
@@ -883,6 +883,16 @@ Host: gabojago.shop
 </thead>
 <tbody>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>startDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">동행 시작 날짜</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>endDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">동행글 마지막 날짜</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">동행글 제목</p></td>
@@ -901,16 +911,6 @@ Host: gabojago.shop
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>region</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">동행 지역</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>startDate</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">동행 시작 날짜</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>endDate</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">동행글 마지막 날짜</p></td>
 </tr>
 </tbody>
 </table>
@@ -958,6 +958,16 @@ Content-Length: 240
 </thead>
 <tbody>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>region</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">동행 지역</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>written</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자인지 여부</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>review</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">동행글 조회수</p></td>
@@ -996,16 +1006,6 @@ Content-Length: 240
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">작성자 닉네임</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>region</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">동행 지역</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>written</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">작성자인지 여부</p></td>
 </tr>
 </tbody>
 </table>
@@ -1065,6 +1065,16 @@ Host: gabojago.shop
 </thead>
 <tbody>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>startDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">동행 시작 날짜</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>endDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">동행글 마지막 날짜</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">동행글 제목</p></td>
@@ -1083,16 +1093,6 @@ Host: gabojago.shop
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>region</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">동행 지역</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>startDate</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">동행 시작 날짜</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>endDate</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">동행글 마지막 날짜</p></td>
 </tr>
 </tbody>
 </table>
@@ -1140,6 +1140,16 @@ Content-Length: 240
 </thead>
 <tbody>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>region</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">동행 지역</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>written</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자인지 여부</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>review</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">동행글 조회수</p></td>
@@ -1178,16 +1188,6 @@ Content-Length: 240
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">작성자 닉네임</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>region</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">동행 지역</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>written</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">작성자인지 여부</p></td>
 </tr>
 </tbody>
 </table>
@@ -1253,7 +1253,7 @@ Content-Length: 26
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-05-03 16:35:02 +0900
+Last updated 2023-05-23 21:18:24 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/main/resources/static/docs/comment.html
+++ b/src/main/resources/static/docs/comment.html
@@ -540,6 +540,11 @@ Content-Length: 113
 </thead>
 <tbody>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].written</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자인지 여부</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].writerNickname</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">작성자 닉네임</p></td>
@@ -553,11 +558,6 @@ Content-Length: 113
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].content</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">댓글 내용</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].written</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">작성자인지 여부</p></td>
 </tr>
 </tbody>
 </table>
@@ -656,6 +656,11 @@ Content-Length: 109
 </thead>
 <tbody>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 내용</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>written</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">작성자인지 여부</p></td>
@@ -669,11 +674,6 @@ Content-Length: 109
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>commentId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">댓글 ID</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 내용</p></td>
 </tr>
 </tbody>
 </table>
@@ -772,6 +772,11 @@ Content-Length: 109
 </thead>
 <tbody>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 내용</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>written</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">작성자인지 여부</p></td>
@@ -785,11 +790,6 @@ Content-Length: 109
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>commentId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">댓글 ID</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 내용</p></td>
 </tr>
 </tbody>
 </table>
@@ -869,7 +869,7 @@ Content-Length: 26
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-05-03 16:35:02 +0900
+Last updated 2023-05-23 21:18:24 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/main/resources/static/docs/community.html
+++ b/src/main/resources/static/docs/community.html
@@ -543,8 +543,8 @@ Content-Length: 759
   "pageable" : {
     "sort" : {
       "empty" : true,
-      "sorted" : false,
-      "unsorted" : true
+      "unsorted" : true,
+      "sorted" : false
     },
     "offset" : 0,
     "pageNumber" : 0,
@@ -552,15 +552,15 @@ Content-Length: 759
     "paged" : true,
     "unpaged" : false
   },
-  "totalElements" : 2,
   "totalPages" : 1,
+  "totalElements" : 2,
   "last" : true,
   "size" : 10,
   "number" : 0,
   "sort" : {
     "empty" : true,
-    "sorted" : false,
-    "unsorted" : true
+    "unsorted" : true,
+    "sorted" : false
   },
   "numberOfElements" : 2,
   "first" : true,
@@ -678,6 +678,16 @@ Content-Length: 759
 <td class="tableblock halign-left valign-top"><p class="tableblock">페이지 여부</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].articleId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">커뮤니티글 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 닉네임</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].title</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">커뮤니티글 제목</p></td>
@@ -691,16 +701,6 @@ Content-Length: 759
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].content</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">커뮤니티글 내용</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].articleId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">커뮤니티글 ID</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].nickname</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 닉네임</p></td>
 </tr>
 </tbody>
 </table>
@@ -1103,7 +1103,7 @@ Content-Length: 26
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-05-03 16:35:02 +0900
+Last updated 2023-05-23 21:18:24 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/main/resources/static/docs/like.html
+++ b/src/main/resources/static/docs/like.html
@@ -611,7 +611,7 @@ Content-Length: 22
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-05-03 16:35:02 +0900
+Last updated 2023-05-23 21:18:24 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/main/resources/static/docs/member.html
+++ b/src/main/resources/static/docs/member.html
@@ -446,46 +446,150 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
 <ul class="sectlevel0">
+<li><a href="#_메일_검증">메일 검증</a>
+<ul class="sectlevel2">
+<li><a href="#_응답">응답</a></li>
+</ul>
+</li>
 <li><a href="#_회원가입">회원가입</a>
 <ul class="sectlevel2">
 <li><a href="#_요청">요청</a></li>
-<li><a href="#_응답">응답</a></li>
+<li><a href="#_응답_2">응답</a></li>
 </ul>
 </li>
 <li><a href="#_회원_정보_조회">회원 정보 조회</a>
 <ul class="sectlevel2">
 <li><a href="#_요청_2">요청</a></li>
-<li><a href="#_응답_2">응답</a></li>
+<li><a href="#_응답_3">응답</a></li>
 </ul>
 </li>
 <li><a href="#_회원_닉네임_수정">회원 닉네임 수정</a>
 <ul class="sectlevel2">
 <li><a href="#_요청_3">요청</a></li>
-<li><a href="#_응답_3">응답</a></li>
+<li><a href="#_응답_4">응답</a></li>
 </ul>
 </li>
 <li><a href="#_회원_비밀번호_수정">회원 비밀번호 수정</a>
 <ul class="sectlevel2">
 <li><a href="#_요청_4">요청</a></li>
-<li><a href="#_응답_4">응답</a></li>
+<li><a href="#_응답_5">응답</a></li>
+</ul>
+</li>
+<li><a href="#_이메일로_회원_비밀번호_변경">이메일로 회원 비밀번호 변경</a>
+<ul class="sectlevel2">
+<li><a href="#_요청_5">요청</a></li>
+<li><a href="#_응답_6">응답</a></li>
 </ul>
 </li>
 <li><a href="#_회원_전화번호_수정">회원 전화번호 수정</a>
 <ul class="sectlevel2">
-<li><a href="#_요청_5">요청</a></li>
-<li><a href="#_응답_5">응답</a></li>
+<li><a href="#_요청_6">요청</a></li>
+<li><a href="#_응답_7">응답</a></li>
 </ul>
 </li>
 <li><a href="#_알람_조회">알람 조회</a>
 <ul class="sectlevel2">
-<li><a href="#_요청_6">요청</a></li>
-<li><a href="#_응답_6">응답</a></li>
+<li><a href="#_요청_7">요청</a></li>
+<li><a href="#_응답_8">응답</a></li>
 </ul>
 </li>
 </ul>
 </div>
 </div>
 <div id="content">
+<h1 id="_메일_검증" class="sect0"><a class="link" href="#_메일_검증">메일 검증</a></h1>
+<div class="openblock partintro">
+<div class="content">
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /auth/signup/mailConfirm HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 34
+Host: gabojago.shop
+
+{
+  "email" : "496300@naver.com"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 이메일</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{
+  "email" : "496300@naver.com"
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_응답"><a class="link" href="#_응답">응답</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+Content-Length: 21
+
+{
+  "data" : "code"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인증코드</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{
+  "data" : "code"
+}</code></pre>
+</div>
+</div>
+</div>
 <h1 id="_회원가입" class="sect0"><a class="link" href="#_회원가입">회원가입</a></h1>
 <div class="sect2">
 <h3 id="_요청"><a class="link" href="#_요청">요청</a></h3>
@@ -521,6 +625,16 @@ Host: gabojago.shop
 </thead>
 <tbody>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>birth</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">패스워드</p></td>
@@ -540,16 +654,6 @@ Host: gabojago.shop
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
 </tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>birth</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">생일</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
-</tr>
 </tbody>
 </table>
 <div class="listingblock">
@@ -566,7 +670,7 @@ Host: gabojago.shop
 </div>
 </div>
 <div class="sect2">
-<h3 id="_응답"><a class="link" href="#_응답">응답</a></h3>
+<h3 id="_응답_2"><a class="link" href="#_응답_2">응답</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -600,14 +704,14 @@ Content-Length: 54
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
 </tr>
 </tbody>
 </table>
@@ -636,7 +740,7 @@ Host: gabojago.shop</code></pre>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_응답_2"><a class="link" href="#_응답_2">응답</a></h3>
+<h3 id="_응답_3"><a class="link" href="#_응답_3">응답</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -698,11 +802,10 @@ Content-Length: 54
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/members/nickname HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer ${AccessToken}
-Content-Length: 54
+Content-Length: 25
 Host: gabojago.shop
 
 {
-  "email" : "test@test.com",
   "nickname" : "test"
 }</code></pre>
 </div>
@@ -722,11 +825,6 @@ Host: gabojago.shop
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">회원 이메일</p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">회원 닉네임</p></td>
@@ -736,14 +834,13 @@ Host: gabojago.shop
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-none hljs">{
-  "email" : "test@test.com",
   "nickname" : "test"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_응답_3"><a class="link" href="#_응답_3">응답</a></h3>
+<h3 id="_응답_4"><a class="link" href="#_응답_4">응답</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -805,13 +902,11 @@ Content-Length: 54
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/members/password HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer ${AccessToken}
-Content-Length: 95
+Content-Length: 32
 Host: gabojago.shop
 
 {
-  "email" : "test@test.com",
-  "exPassword" : "test123!@#",
-  "newPassword" : "test1234!@#"
+  "newPassword" : "Test123!"
 }</code></pre>
 </div>
 </div>
@@ -829,16 +924,6 @@ Host: gabojago.shop
 </tr>
 </thead>
 <tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">회원 이메일</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>exPassword</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">현재 비밀번호</p></td>
-</tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>newPassword</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
@@ -849,116 +934,7 @@ Host: gabojago.shop
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-none hljs">{
-  "email" : "test@test.com",
-  "exPassword" : "test123!@#",
-  "newPassword" : "test1234!@#"
-}</code></pre>
-</div>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_응답_4"><a class="link" href="#_응답_4">응답</a></h3>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Content-Type: application/json
-X-Content-Type-Options: nosniff
-X-XSS-Protection: 1; mode=block
-Cache-Control: no-cache, no-store, max-age=0, must-revalidate
-Pragma: no-cache
-Expires: 0
-X-Frame-Options: DENY
-Content-Length: 54
-
-{
-  "email" : "test@test.com",
-  "nickname" : "test"
-}</code></pre>
-</div>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Path</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">회원 이메일</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">회원 닉네임</p></td>
-</tr>
-</tbody>
-</table>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{
-  "email" : "test@test.com",
-  "nickname" : "test"
-}</code></pre>
-</div>
-</div>
-</div>
-<h1 id="_회원_전화번호_수정" class="sect0"><a class="link" href="#_회원_전화번호_수정">회원 전화번호 수정</a></h1>
-<div class="sect2">
-<h3 id="_요청_5"><a class="link" href="#_요청_5">요청</a></h3>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/members/phone HTTP/1.1
-Content-Type: application/json;charset=UTF-8
-Authorization: Bearer ${AccessToken}
-Content-Length: 60
-Host: gabojago.shop
-
-{
-  "email" : "test@test.com",
-  "phone" : "010-0000-0000"
-}</code></pre>
-</div>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Path</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">회원 이메일</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>phone</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">새로운 전화번호</p></td>
-</tr>
-</tbody>
-</table>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{
-  "email" : "test@test.com",
-  "phone" : "010-0000-0000"
+  "newPassword" : "Test123!"
 }</code></pre>
 </div>
 </div>
@@ -1018,9 +994,201 @@ Content-Length: 54
 </div>
 </div>
 </div>
-<h1 id="_알람_조회" class="sect0"><a class="link" href="#_알람_조회">알람 조회</a></h1>
+<h1 id="_이메일로_회원_비밀번호_변경" class="sect0"><a class="link" href="#_이메일로_회원_비밀번호_변경">이메일로 회원 비밀번호 변경</a></h1>
+<div class="sect2">
+<h3 id="_요청_5"><a class="link" href="#_요청_5">요청</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /auth/findPw HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 34
+Host: gabojago.shop
+
+{
+  "email" : "496300@naver.com"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 이메일</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{
+  "email" : "496300@naver.com"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_응답_6"><a class="link" href="#_응답_6">응답</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+Content-Length: 26
+
+{
+  "status" : "SUCCESS"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>status</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 상태</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{
+  "status" : "SUCCESS"
+}</code></pre>
+</div>
+</div>
+</div>
+<h1 id="_회원_전화번호_수정" class="sect0"><a class="link" href="#_회원_전화번호_수정">회원 전화번호 수정</a></h1>
 <div class="sect2">
 <h3 id="_요청_6"><a class="link" href="#_요청_6">요청</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/members/phone HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer ${AccessToken}
+Content-Length: 31
+Host: gabojago.shop
+
+{
+  "phone" : "010-0000-0000"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>phone</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">새로운 전화번호</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{
+  "phone" : "010-0000-0000"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_응답_7"><a class="link" href="#_응답_7">응답</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+Content-Length: 54
+
+{
+  "email" : "test@test.com",
+  "nickname" : "test"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 이메일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 닉네임</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{
+  "email" : "test@test.com",
+  "nickname" : "test"
+}</code></pre>
+</div>
+</div>
+</div>
+<h1 id="_알람_조회" class="sect0"><a class="link" href="#_알람_조회">알람 조회</a></h1>
+<div class="sect2">
+<h3 id="_요청_7"><a class="link" href="#_요청_7">요청</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/members/alarms?page=0&amp;size=10 HTTP/1.1
@@ -1052,7 +1220,7 @@ Host: gabojago.shop</code></pre>
 </table>
 </div>
 <div class="sect2">
-<h3 id="_응답_6"><a class="link" href="#_응답_6">응답</a></h3>
+<h3 id="_응답_8"><a class="link" href="#_응답_8">응답</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1076,8 +1244,8 @@ Content-Length: 685
   "pageable" : {
     "sort" : {
       "empty" : true,
-      "sorted" : false,
-      "unsorted" : true
+      "unsorted" : true,
+      "sorted" : false
     },
     "offset" : 0,
     "pageNumber" : 0,
@@ -1085,15 +1253,15 @@ Content-Length: 685
     "paged" : true,
     "unpaged" : false
   },
-  "totalElements" : 1,
   "totalPages" : 1,
+  "totalElements" : 1,
   "last" : true,
   "size" : 10,
   "number" : 0,
   "sort" : {
     "empty" : true,
-    "sorted" : false,
-    "unsorted" : true
+    "unsorted" : true,
+    "sorted" : false
   },
   "numberOfElements" : 1,
   "first" : true,
@@ -1211,6 +1379,11 @@ Content-Length: 685
 <td class="tableblock halign-left valign-top"><p class="tableblock">페이지 여부</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 주인 닉네임</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].alarmType</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">알람 타입 COMMENT , LIKE</p></td>
@@ -1230,11 +1403,6 @@ Content-Length: 685
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">알람이 발생한 게시글 ID</p></td>
 </tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].nickname</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 주인 닉네임</p></td>
-</tr>
 </tbody>
 </table>
 <div class="listingblock">
@@ -1250,8 +1418,8 @@ Content-Length: 685
   "pageable" : {
     "sort" : {
       "empty" : true,
-      "sorted" : false,
-      "unsorted" : true
+      "unsorted" : true,
+      "sorted" : false
     },
     "offset" : 0,
     "pageNumber" : 0,
@@ -1259,15 +1427,15 @@ Content-Length: 685
     "paged" : true,
     "unpaged" : false
   },
-  "totalElements" : 1,
   "totalPages" : 1,
+  "totalElements" : 1,
   "last" : true,
   "size" : 10,
   "number" : 0,
   "sort" : {
     "empty" : true,
-    "sorted" : false,
-    "unsorted" : true
+    "unsorted" : true,
+    "sorted" : false
   },
   "numberOfElements" : 1,
   "first" : true,
@@ -1280,7 +1448,7 @@ Content-Length: 685
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-05-11 19:34:13 +0900
+Last updated 2023-05-24 19:32:57 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/main/resources/static/docs/qna.html
+++ b/src/main/resources/static/docs/qna.html
@@ -545,8 +545,8 @@ Content-Length: 792
   "pageable" : {
     "sort" : {
       "empty" : true,
-      "sorted" : false,
-      "unsorted" : true
+      "unsorted" : true,
+      "sorted" : false
     },
     "offset" : 0,
     "pageNumber" : 0,
@@ -554,15 +554,15 @@ Content-Length: 792
     "paged" : true,
     "unpaged" : false
   },
-  "totalElements" : 2,
   "totalPages" : 1,
+  "totalElements" : 2,
   "last" : true,
   "size" : 10,
   "number" : 0,
   "sort" : {
     "empty" : true,
-    "sorted" : false,
-    "unsorted" : true
+    "unsorted" : true,
+    "sorted" : false
   },
   "numberOfElements" : 2,
   "first" : true,
@@ -680,6 +680,16 @@ Content-Length: 792
 <td class="tableblock halign-left valign-top"><p class="tableblock">페이지 여부</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">동행글 내용</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].review</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">동행글 조회수</p></td>
@@ -698,16 +708,6 @@ Content-Length: 792
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].id</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">동행글 ID</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].nickname</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 닉네임</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].content</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">동행글 내용</p></td>
 </tr>
 </tbody>
 </table>
@@ -1152,7 +1152,7 @@ Content-Length: 26
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-05-03 16:35:02 +0900
+Last updated 2023-05-23 21:18:24 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/test/java/com/example/gabojago_server/config/TestSecurityConfig.java
+++ b/src/test/java/com/example/gabojago_server/config/TestSecurityConfig.java
@@ -22,8 +22,9 @@ public class TestSecurityConfig {
                 .csrf().disable()   //rest api이므로 csrf 보안 사용 x
                 .formLogin().disable()
                 .authorizeRequests()
-                .antMatchers("/auth/signup").permitAll()
-                .antMatchers("/auth/login").permitAll()
+                .antMatchers("/auth/signup/**").permitAll()
+                .antMatchers("/auth/login/**").permitAll()
+                .antMatchers("/auth/findPw/**").permitAll()
                 .antMatchers("/login/**").permitAll()
                 .antMatchers("/oauth2/**").permitAll()
                 .antMatchers("/api/accompany/**").permitAll()

--- a/src/test/java/com/example/gabojago_server/web/controller/member/AuthControllerTest.java
+++ b/src/test/java/com/example/gabojago_server/web/controller/member/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package com.example.gabojago_server.web.controller.member;
 
 import com.example.gabojago_server.config.TestSecurityConfig;
+import com.example.gabojago_server.dto.request.member.EmailRequestDto;
 import com.example.gabojago_server.dto.request.member.LoginRequestDto;
 import com.example.gabojago_server.dto.request.member.MemberRequestDto;
 import com.example.gabojago_server.dto.response.member.MemberResponseDto;
@@ -8,7 +9,6 @@ import com.example.gabojago_server.jwt.JwtTokenProvider;
 import com.example.gabojago_server.service.mail.ChangePwEmailService;
 import com.example.gabojago_server.service.mail.SignupEmailService;
 import com.example.gabojago_server.service.member.AuthService;
-import com.example.gabojago_server.service.member.MemberService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -19,7 +19,6 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.operation.preprocess.Preprocessors;
@@ -29,13 +28,8 @@ import java.util.Map;
 
 import static com.example.gabojago_server.web.controller.restDocs.RestDocsUtils.onlyContent;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
-import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler;
@@ -97,16 +91,15 @@ public class AuthControllerTest {
     @Test
     @DisplayName("[POST] [/auth/signup/mailConfirm] 회원가입 시 이메일 인증 테스트")
     public void mailConfirmTest() throws Exception {
-        String email = "test@test.com";
-        String ePw = emailService.createKey();
+        EmailRequestDto requestDto = createEmailRequestDto();
 
         mockMvc.perform(post("/auth/signup/mailConfirm")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(email)))
+                        .content(objectMapper.writeValueAsString(requestDto)))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(handler().methodName("mailConfirm"))
-                .andDo(document("member/auth/signup/mailConfirm",
+                .andDo(document("member/auth/mailConfirm",
                         Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
                         Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
                         requestFields(
@@ -120,16 +113,13 @@ public class AuthControllerTest {
     }
 
     @Test
-    @DisplayName("[POST] [/auth/login/findPw] 로그인 시 비밀번호 찾기 테스트")
+    @DisplayName("[POST] [/auth/findPw] 로그인 시 비밀번호 찾기 테스트")
     public void findPwTest() throws Exception {
-        String email = "test@test.com";
-        String ePw = pwEmailService.createKey();
-
-        doNothing().when(authService).changeTempPw(email, ePw);
+        EmailRequestDto requestDto = createEmailRequestDto();
 
         mockMvc.perform(post("/auth/findPw")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(email)))
+                        .content(objectMapper.writeValueAsString(requestDto)))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(handler().methodName("findPw"))
@@ -137,7 +127,7 @@ public class AuthControllerTest {
                         Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
                         Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
                         requestFields(
-                                fieldWithPath(email).description("회원 이메일")
+                                fieldWithPath("email").description("회원 이메일")
                         ),
                         responseFields(
                                 fieldWithPath("status").description("응답 상태")
@@ -202,6 +192,10 @@ public class AuthControllerTest {
                 .email("test@test.com")
                 .nickname("test")
                 .build();
+    }
+
+    private EmailRequestDto createEmailRequestDto() {
+        return new EmailRequestDto("496300@naver.com");
     }
 
 

--- a/src/test/java/com/example/gabojago_server/web/controller/member/AuthControllerTest.java
+++ b/src/test/java/com/example/gabojago_server/web/controller/member/AuthControllerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -28,6 +29,7 @@ import java.util.Map;
 
 import static com.example.gabojago_server.web.controller.restDocs.RestDocsUtils.onlyContent;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -92,6 +94,10 @@ public class AuthControllerTest {
     @DisplayName("[POST] [/auth/signup/mailConfirm] 회원가입 시 이메일 인증 테스트")
     public void mailConfirmTest() throws Exception {
         EmailRequestDto requestDto = createEmailRequestDto();
+        String code = "code";
+
+        given(authService.findMember(requestDto.getEmail())).willReturn(false);
+        given(emailService.sendSimpleMessage(requestDto.getEmail())).willReturn(code);
 
         mockMvc.perform(post("/auth/signup/mailConfirm")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -116,6 +122,11 @@ public class AuthControllerTest {
     @DisplayName("[POST] [/auth/findPw] 로그인 시 비밀번호 찾기 테스트")
     public void findPwTest() throws Exception {
         EmailRequestDto requestDto = createEmailRequestDto();
+        String newPassword = "newPassword";
+
+        given(authService.findMember(requestDto.getEmail())).willReturn(true);
+        given(pwEmailService.sendSimpleMessage(requestDto.getEmail())).willReturn(newPassword);
+        willDoNothing().given(authService).changeTempPw(requestDto.getEmail(),newPassword);
 
         mockMvc.perform(post("/auth/findPw")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/example/gabojago_server/web/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/example/gabojago_server/web/controller/member/MemberControllerTest.java
@@ -103,7 +103,7 @@ class MemberControllerTest {
     public void changeMemberNicknameTest() throws Exception {
         ChangeNickNameRequestDto request = createChangeNicknameRequestDto();
 
-        given(memberService.changeNickname(request.getEmail(), request.getNickname()))
+        given(memberService.changeNickname(1L, request.getNickname()))
                 .willReturn(createMemberResponseDto());
 
         mockMvc.perform(post("/api/members/nickname")
@@ -134,7 +134,7 @@ class MemberControllerTest {
     public void changeMemberPasswordTest() throws Exception {
         ChangePasswordRequestDto request = createChangePasswordRequestDto();
 
-        given(memberService.changePassword(request.getEmail(), request.getExPassword(), request.getNewPassword()))
+        given(memberService.changePassword(1L, request.getNewPassword()))
                 .willReturn(createMemberResponseDto());
 
         mockMvc.perform(post("/api/members/password")
@@ -150,7 +150,6 @@ class MemberControllerTest {
                         Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
                         requestFields(
                                 fieldWithPath("email").description("회원 이메일"),
-                                fieldWithPath("exPassword").description("현재 비밀번호"),
                                 fieldWithPath("newPassword").description("새로운 비밀번호")
                         ),
                         responseFields(
@@ -166,7 +165,7 @@ class MemberControllerTest {
     public void changeMemberPhoneTest() throws Exception {
         ChangePhoneRequestDto request = createChangePhoneRequestDto();
 
-        given(memberService.changePhone(request.getEmail(), request.getPhone()))
+        given(memberService.changePhone(1L, request.getPhone()))
                 .willReturn(createMemberResponseDto());
 
         mockMvc.perform(post("/api/members/phone")
@@ -271,19 +270,19 @@ class MemberControllerTest {
 
     private ChangeNickNameRequestDto createChangeNicknameRequestDto() {
         return new ChangeNickNameRequestDto(
-                "test@test.com", "test"
+                "test"
         );
     }
 
     private ChangePasswordRequestDto createChangePasswordRequestDto() {
         return new ChangePasswordRequestDto(
-                "test@test.com", "test123!@#", "test1234!@#"
+                 "test1234!@#"
         );
     }
 
     private ChangePhoneRequestDto createChangePhoneRequestDto() {
         return new ChangePhoneRequestDto(
-                "test@test.com", "010-0000-0000"
+                "010-0000-0000"
         );
     }
 }

--- a/src/test/java/com/example/gabojago_server/web/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/example/gabojago_server/web/controller/member/MemberControllerTest.java
@@ -118,7 +118,6 @@ class MemberControllerTest {
                         Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
                         Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
                         requestFields(
-                                fieldWithPath("email").description("회원 이메일"),
                                 fieldWithPath("nickname").description("회원 닉네임")
                         ),
                         responseFields(
@@ -149,7 +148,6 @@ class MemberControllerTest {
                         Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
                         Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
                         requestFields(
-                                fieldWithPath("email").description("회원 이메일"),
                                 fieldWithPath("newPassword").description("새로운 비밀번호")
                         ),
                         responseFields(
@@ -180,7 +178,6 @@ class MemberControllerTest {
                         Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
                         Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
                         requestFields(
-                                fieldWithPath("email").description("회원 이메일"),
                                 fieldWithPath("phone").description("새로운 전화번호")
                         ),
                         responseFields(
@@ -276,7 +273,7 @@ class MemberControllerTest {
 
     private ChangePasswordRequestDto createChangePasswordRequestDto() {
         return new ChangePasswordRequestDto(
-                 "test1234!@#"
+                "Test123!"
         );
     }
 


### PR DESCRIPTION
### 관련 이슈 번호
#21 

### 변경 사항
- config 패키지에 MailConfig 파일을 추가했습니다.
- 회원가입 시 이메일 인증을 위한 SignupEmailService를 추가했습니다.
- 비밀번호 재설정을 위해 임시 비밀번호를 전송하는 ChangePwEmailService를 추가했습니다.
- AuthController에 회원가입 시 이메일 인증을 위한 mailConfirm 메소드를 추가했습니다.
- AuthController에 임시 비밀번호를 발급하고 임의로 회원 비밀번호를 변경하는 findPw 메소드를 추가했습니다.
- AuthService에 changeTempPw와 findMember를 통해 회원 비밀번호를 임의로 변경하고 회원인지 여부를 체크하도록 했습니다.
- MemberController에서 현재 로그인한 사용자의 id를 전달함으로써 기존에 email 주소를 통해 회원을 확인하고 회원 정보를 바꾸는 로직을 id를 통해 확인 후 변경하도록 수정했습니다. (따라서 관련 requestDto들도 변경)
- AuthControllerTest에 위에 추가한 메일 인증 관련 테스트를 작성했습니다.
- MemberControllerTest에도 변경된 부분과 관련해 테스트를 수정했습니다.

### 리뷰 시 주의사항, 기타사항
- 메일 서버 관련 환경 설정은 노션에 올려놓았습니다.
- application 실행 시 에러 로그가 따로 발생하지는 않습니다(debug로 설정 후 확인)
- 이전에 bootJar 실행 시 MemberService 빈이 없다는 오류 로그가 확인되었습니다.
- 최근에는 bootJar 실행 시 시간이 오래 걸려 돌아가지 않습니다.
- 가장 최근에 bootJar 실행 시 확인 했던 부분은 AuthControllerTest의 82번째 line에서 assertionError가 나타난다는 것이었습니다(200 status를 기대하지만 402 error 발생)
- approve 없이 한 번 검토 부탁드립니다


** 추가내역
- 비밀번호 정규식 표현에 이상이 있어 수정하였습니다
- 임시 비밀번호 전송 메일 양식에 오타가 있어 수정하였습니다
- 테스트 코드에 불필요한 requestField가 있어 삭제하였습니다