### PR TITLE
feat : [#25] 로그를 파일로 관리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ out/
 application.properties
 application.ymlapplication-oauth.properties
 application-oauth.properties
+logs/

--- a/src/main/java/com/example/gabojago_server/web/config/WebConfig.java
+++ b/src/main/java/com/example/gabojago_server/web/config/WebConfig.java
@@ -2,9 +2,11 @@ package com.example.gabojago_server.web.config;
 
 import com.example.gabojago_server.jwt.JwtTokenProvider;
 import com.example.gabojago_server.web.argument.TokenArgumentResolver;
+import com.example.gabojago_server.web.interceptor.LogInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
@@ -14,9 +16,15 @@ import java.util.List;
 public class WebConfig implements WebMvcConfigurer {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final LogInterceptor logInterceptor;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new TokenArgumentResolver(jwtTokenProvider));
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(logInterceptor);
     }
 }

--- a/src/main/java/com/example/gabojago_server/web/filter/ServletWrappingFilter.java
+++ b/src/main/java/com/example/gabojago_server/web/filter/ServletWrappingFilter.java
@@ -1,0 +1,24 @@
+package com.example.gabojago_server.web.filter;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class ServletWrappingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        ContentCachingRequestWrapper wrappingRequest = new ContentCachingRequestWrapper(request);
+        ContentCachingResponseWrapper wrappingResponse = new ContentCachingResponseWrapper(response);
+        filterChain.doFilter(wrappingRequest, wrappingResponse);
+        wrappingResponse.copyBodyToResponse();
+    }
+}

--- a/src/main/java/com/example/gabojago_server/web/interceptor/LogInterceptor.java
+++ b/src/main/java/com/example/gabojago_server/web/interceptor/LogInterceptor.java
@@ -1,0 +1,80 @@
+package com.example.gabojago_server.web.interceptor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LogInterceptor implements HandlerInterceptor {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+        ContentCachingRequestWrapper cachingRequest = (ContentCachingRequestWrapper) request;
+        ContentCachingResponseWrapper cachingResponse = (ContentCachingResponseWrapper) response;
+        MDC.put("ID", UUID.randomUUID().toString());
+        writeLogAboutBody(
+                new String(cachingRequest.getContentAsByteArray()),
+                new String(cachingResponse.getContentAsByteArray()));
+        if (hasException(ex)) writeLogAboutHeader(request, response);
+        MDC.clear();
+    }
+
+    private void writeLogAboutBody(String requestBody, String responseBody) throws Exception {
+        log.info(
+                "RequestBody : [{}] / ResponseBody : [{}]",
+                objectMapper.readTree(requestBody),
+                objectMapper.readTree(responseBody)
+        );
+    }
+
+    private boolean hasException(Exception ex) {
+        return ex != null;
+    }
+
+    private void writeLogAboutHeader(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        log.error(
+                "Request Header : [{}]",
+                objectMapper.writeValueAsString(LogHeader.from(request))
+        );
+    }
+
+    @Getter
+    static class LogHeader {
+        private String contentType = "default";
+        private Map<String, String> headers = new HashMap<>();
+        private String uri = "default";
+
+        public static LogHeader from(HttpServletRequest request) {
+            LogHeader logHeader = new LogHeader();
+            logHeader.contentType = request.getContentType();
+            logHeader.uri = request.getRequestURI();
+            logHeader.headers = new HashMap<>();
+            Enumeration<String> headerNames = request.getHeaderNames();
+            while (headerNames.hasMoreElements()) {
+                String headerName = headerNames.nextElement();
+                logHeader.headers.put(headerName, request.getHeader(headerName));
+            }
+            return logHeader;
+        }
+
+    }
+
+
+}

--- a/src/main/resources/logback-spring-local.xml
+++ b/src/main/resources/logback-spring-local.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/> <!--디폴스 설정 include -->
+    <include
+            resource="org/springframework/boot/logging/logback/console-appender.xml"/> <!--콘솔에 로그를 찍기위해 console-appender include-->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/src/main/resources/logback-spring-prod.xml
+++ b/src/main/resources/logback-spring-prod.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <property resource="logback-variables.properties"/>
+
+    <appender name="REQUEST-RESPONSE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/logRequest-response.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/info/logRequest-response.log.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>100MB</maxFileSize> <!-- 한 파일의 최대 용량 -->
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>180</maxHistory> <!-- 한 파일의 최대 저장 기한 (단위 : 일) -->
+        </rollingPolicy>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>
+                [REQUEST-RESPONSE] %X{ID} ${LOG_PATTERN}
+            </pattern>
+            <outputPatternAsHeader>true</outputPatternAsHeader>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="REQUEST-RESPONSE"/>
+    </root>
+</configuration>

--- a/src/main/resources/logback-variables.properties
+++ b/src/main/resources/logback-variables.properties
@@ -1,0 +1,2 @@
+LOG_DIR=logs
+LOG_PATTERN=[%-5level] %d{yyyy-MM--DD HH:mm:ss} [%thread] [%logger{50}:%line] - %msg%n


### PR DESCRIPTION
### 관련 이슈 번호
#25

### 변경 사항
- 컨벤션 패이지에 application.yml 파일 추가 설정 정보 확인해주세요
- spring.profiles.active 설정이 없으시다면 local 로 설정 부탁드립니다. (local 시 콘솔로만 로그를 출력합니다.)
- 로그 전략은 prod 환경에서 logs/ 하위에 하루 단위로 로그를 기록합니다.
- 로그는 정상 (request,response) 시 body 값을 로그로 남기고 , 에러 발생시 request header 를 추가해서 로그를 남깁니다 .
- ServletWrappingFilter : request body ,response body 는 두번 이상 읽을 수 없기 때문에 캐싱해주는 filter 입니다.
-  LogInterceptor : 매 요청마다 log 를 기록하는 클래스입니다.
